### PR TITLE
[I-14] 데이터 인프라 확장

### DIFF
--- a/gaemi-project/docker-compose.yml
+++ b/gaemi-project/docker-compose.yml
@@ -56,9 +56,49 @@ services:
     command: ["npm", "run", "dev", "--", "--host"] 
     depends_on:
       - backend
+  
+  # 4. zookeeper (Kafka 관리자)
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.6.0
+    container_name: gaemi_zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    volumes:
+      # Confluent는 데이터 경로가 다릅니다 (/var/lib/zookeeper/data)
+      - zookeeper_data:/var/lib/zookeeper/data
 
+  # 5. kafka 
+  kafka:
+    image: confluentinc/cp-kafka:7.6.0
+    container_name: gaemi_kafka
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      
+      # [리스너 설정] 내부용(kafka:29092)과 외부용(localhost:9092)을 분리합니다.
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      
+      # [필수] 싱글 노드 모드 설정 (이거 없으면 실행 안 됨)
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    
+    depends_on:
+      - zookeeper
+    volumes:
+      # Confluent 데이터 경로 (/var/lib/kafka/data)
+      - kafka_data:/var/lib/kafka/data
 
 # (나중에 data-pjt 서비스 여기에 추가)
 # Docker가 관리할 볼륨 정의
 volumes:
   postgres_data:
+  zookeeper_data:
+  kafka_data:


### PR DESCRIPTION
## 📌 개요
Kafka & Zookeeper를 Docker Compose 기반으로 프로젝트에 추가했습니다. Backend가 직접 실시간 데이터를 받지 않고, Kafka를 통해 안정적으로 메시지를 처리할 수 있도록 구조를 확장했습니다.

## ✨ 주요 변경 사항
- [x] docker-compose.yml에 Zookeeper 서비스 추가
- [x] docker-compose.yml에 Kafka 서비스 추가
- [x] Kafka 데이터/메타데이터용 볼륨(kafka_data, zookeeper_data) 추가

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [I-14](https://github.com/gAemI-AI/gAemI-AI/issues/14)

## 🙏 To Reviewers
<!-- 코드 이해를 위해 참고할 수 있는 자료나 팀원에게 전달할 내용 입력해주세요. -->
  - Backend/Flink/Producer가 모두 kafka:9092로 접속하는 구조라 네트워크 설정이 정확한지 체크해주세요.
  - Kafka 토픽 생성 시 정상적으로 동작하는지 로컬에서 한 번씩 테스트 부탁드립니다.
