### PR TITLE
[I-21] 실시간 뉴스 데이터 kafka 구축

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 
 ## ✨ 기술개발문서
-- 
+- [왜 Google RSS를 사용했나요?](https://www.notion.so/Google-RSS-2c00c3d3c9ea803ca500d5374af9cdc1?source=copy_link)
 - 
 
 ## 📌 Git 협업 전략

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## ✨ 기술개발문서
 - [왜 Google RSS를 사용했나요?](https://www.notion.so/Google-RSS-2c00c3d3c9ea803ca500d5374af9cdc1?source=copy_link)
-- 
+- [중복방지를 위한 2단계 방어선 구축! In-Memory Filtering + Kafka Log Compaction](https://www.notion.so/2-In-Memory-Filtering-Kafka-Log-Compaction-2c00c3d3c9ea802eb722e7f050803e6c?source=copy_link)
 
 ## 📌 Git 협업 전략
 -

--- a/gaemi-project/data-pjt/producer-news/Dockerfile
+++ b/gaemi-project/data-pjt/producer-news/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "main.py"]

--- a/gaemi-project/data-pjt/producer-news/config.py
+++ b/gaemi-project/data-pjt/producer-news/config.py
@@ -1,0 +1,13 @@
+# data-pjt/producer-news/config.py
+import os
+
+# Kafka 설정
+KAFKA_BROKER = "gaemi_kafka:29092"
+KAFKA_TOPIC_NEWS = "news-raw"
+
+# 구글 뉴스 RSS URL 포맷 / 
+# {}: keyword는 종목명(한글)로 추가
+RSS_URL_FORMAT = "https://news.google.com/rss/search?q={}&hl=ko&gl=KR&ceid=KR:ko"
+
+# 수집 주기 (초)
+CRAWL_INTERVAL = 60

--- a/gaemi-project/data-pjt/producer-news/main.py
+++ b/gaemi-project/data-pjt/producer-news/main.py
@@ -131,6 +131,7 @@ class NewsProducer:
                 news_data = {
                     "news_id": news_id,
                     "stock_code": stock_code,
+                    "stock_name": stock_name,
                     "title": entry.title,
                     "link": entry.link,
                     "source": entry.get('source', {}).get('title', 'Google News'),

--- a/gaemi-project/data-pjt/producer-news/main.py
+++ b/gaemi-project/data-pjt/producer-news/main.py
@@ -1,0 +1,171 @@
+# data-pjt/producer-news/main.py
+import time
+import json
+import logging
+import feedparser
+import schedule
+import hashlib
+from kafka import KafkaProducer
+from kafka.admin import KafkaAdminClient, NewTopic  # 관리자 도구 임포트
+from kafka.errors import TopicAlreadyExistsError    # 에러 임포트
+from config import *
+from datetime import datetime
+
+# docker내에서 로그 확인을 위한 장치
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class NewsProducer:
+    def __init__(self):
+        # 토픽 자동 생성 및 설정 (Compact 모드)
+        self.create_topic_if_not_exists()
+
+        self.producer = KafkaProducer(
+            bootstrap_servers=KAFKA_BROKER,
+            value_serializer=lambda v: json.dumps(v).encode('utf-8'),
+            api_version=(2, 5, 0),
+            retries=5
+        )
+        # 중복 방지용 (URL 해시 저장)
+        self.processed_ids = set()
+        
+        # 수집할 종목 목록 (나중엔 DB로 연동)
+        self.target_keywords = [
+            {"code": "005930", "name": "삼성전자"},
+            {"code": "000660", "name": "SK하이닉스"},
+            {"code": "035420", "name": "NAVER"},
+            {"code": "005380", "name": "현대차"}
+        ]
+
+    # 토픽 생성 로직 (토픽 청소 정책 설정을 위해)
+    def create_topic_if_not_exists(self):
+        try:
+            # Admin Client 연결
+            admin_client = KafkaAdminClient(
+                bootstrap_servers=KAFKA_BROKER,
+                api_version=(2, 5, 0)
+            )
+            
+            # 현재 토픽 목록 가져오기
+            existing_topics = admin_client.list_topics()
+            
+            # 아직 해당 토픽이 존재하지 않는다면
+            if KAFKA_TOPIC_NEWS not in existing_topics:
+                logger.info(f"토픽 '{KAFKA_TOPIC_NEWS}' 생성 중 (Log Compaction 적용)...")
+                
+                # 토픽 설정 정의
+                topic_list = [NewTopic(
+                    name=KAFKA_TOPIC_NEWS, 
+                    num_partitions=1, 
+                    replication_factor=1,
+                    # 청소 정책을 하이브리드로 설정
+                    # kafka 토픽은 시간이 지나면 삭제가 기본 'Compact'는 최신 상태만 남기는 Update 방식
+                    # 두가지 모두 적용
+                    topic_configs={'cleanup.policy': 'delete, compact'}
+                )]
+                
+                admin_client.create_topics(new_topics=topic_list, validate_only=False)
+                logger.info(f"✅ 토픽 '{KAFKA_TOPIC_NEWS}' 생성 완료!")
+            else:
+                logger.info(f"ℹ️ 토픽 '{KAFKA_TOPIC_NEWS}' 이미 존재함. 생성 건너뜀.")
+                
+            admin_client.close()
+            
+        except Exception as e:
+            logger.error(f"⚠️ 토픽 생성 중 오류 (이미 존재할 수 있음): {e}")
+
+
+    def generate_id(self, link):
+        """URL을 기반으로 고유 ID 생성 (MD5 해시)"""
+        return hashlib.md5(link.encode('utf-8')).hexdigest()
+
+    def fetch_and_send(self):
+        logger.info("뉴스 수집 시작...")
+        
+        for target in self.target_keywords:
+            stock_name = target['name']
+            stock_code = target['code']
+            
+            # 1. RSS 데이터 가져오기
+            rss_url = RSS_URL_FORMAT.format(stock_name)
+            feed = feedparser.parse(rss_url)
+            
+            if not feed.entries: # feed.entries는 리스트 형태
+                continue
+
+            count = 0
+
+            # 2. 각 뉴스 항목 파싱
+            for entry in feed.entries:
+                """
+                {
+                    'title': '삼성전자, 역대 최대 매출 기록… 반도체 회복세',
+                    'link': 'https://news.google.com/articles/xxxxx',
+                    'summary': '삼성전자가 올해 4분기 역대 최대 실적을 기록했다...',
+                    'published': 'Mon, 02 Dec 2024 09:15:00 GMT',
+                    'published_parsed': time.struct_time(...),
+                    'source': {
+                        'title': '한국경제'
+                    }
+                }
+
+                """
+                # 중복 방지를 위한 뉴스 아이디 생성
+                news_id = self.generate_id(entry.link)
+                
+                # 이미 보낸 뉴스면 건너뛰기 (중복 제거)
+                if news_id in self.processed_ids:
+                    continue
+                
+                # 아직 보내지 않은 뉴스면 전송
+
+                # 3. 데이터 포맷팅
+                published_struct = entry.get('published_parsed') #published_parsed: RSS 피드에서 제공하는 날짜, 시간 정보
+
+                if published_struct:
+                    # feedparser는 time.struct_time(Unix timestap) 객체로 변환해줌
+                    timestamp = int(time.mktime(published_struct) * 1000) # kafka, DB에 넣기 좋은 숫자 형태로 변환
+                else: # 정보가 없다면
+                    timestamp = int(time.time() * 1000) # 현재 시간으로 주입
+
+                news_data = {
+                    "news_id": news_id,
+                    "stock_code": stock_code,
+                    "title": entry.title,
+                    "link": entry.link,
+                    "source": entry.get('source', {}).get('title', 'Google News'),
+                    "published_at": timestamp,
+                    "crawled_at": int(time.time() * 1000) # 현재 시간
+                }
+
+                # 4. Kafka 전송
+                # key를 설정하여 Log Compaction 활용 가능하게 함
+                self.producer.send(
+                    KAFKA_TOPIC_NEWS, 
+                    key=news_id.encode('utf-8'), 
+                    value=news_data
+                )
+                
+                self.processed_ids.add(news_id)
+                count += 1
+            
+            if count > 0:
+                logger.info(f"✅ [{stock_name}] 새 뉴스 {count}건 전송 완료")
+        
+        self.producer.flush()
+
+    def run(self):
+        # 최초 실행
+        self.fetch_and_send()
+        
+        # 주기적 실행 등록
+        schedule.every(CRAWL_INTERVAL).seconds.do(self.fetch_and_send)
+        
+        logger.info(f"🚀 News Producer 시작 (주기: {CRAWL_INTERVAL}초)")
+        while True:
+            schedule.run_pending()
+            time.sleep(1)
+
+if __name__ == "__main__":
+    producer = NewsProducer()
+    producer.run()

--- a/gaemi-project/data-pjt/producer-news/requirements.txt
+++ b/gaemi-project/data-pjt/producer-news/requirements.txt
@@ -1,0 +1,4 @@
+kafka-python==2.0.2
+feedparser # RSS 파싱을 위한 라이브러리
+requests
+schedule

--- a/gaemi-project/docker-compose.yml
+++ b/gaemi-project/docker-compose.yml
@@ -93,7 +93,7 @@ services:
     volumes:
       - kafka_data:/var/lib/kafka/data
 
-# Kafka UI 서비스
+  # Kafka UI 서비스
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     container_name: gaemi_kafka_ui
@@ -106,7 +106,7 @@ services:
     depends_on:
       - kafka
 
-    # 6. 주식 데이터 수집기 (Producer)
+  # 6. 주식 데이터 수집기 (Producer)
   producer-stock:
     build:
       context: ./data-pjt/producer-stock
@@ -121,7 +121,19 @@ services:
       - kafka
     restart: on-failure
 
-# (나중에 data-pjt 서비스 여기에 추가)
+  # 7. 뉴스 데이터 수집기 (Procuer2)
+  producer-news:
+    build:
+      context: ./data-pjt/producer-news
+    container_name: gaemi_producer_news
+    volumes:
+      - ./data-pjt/producer-news:/app
+    environment:
+      - PYTHONUNBUFFERED=1
+    depends_on:
+      - kafka
+    restart: on-failure
+
 # Docker가 관리할 볼륨 정의
 volumes:
   postgres_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "gAemI-AI",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
## 📌 개요
RAG(검색 증강 생성) 및 뉴스 피드 서비스를 위한 실시간 뉴스 데이터 수집기(producer-news)를 구현했습니다. Google News RSS를 활용하여 주식 관련 뉴스를 수집하고 Kafka로 전송하는 파이프라인을 구축했습니다.

## ✨ 주요 변경 사항
- [x] NewsProducer 클래스 구현: Google News RSS 크롤링 및 데이터 파싱 로직 구현
- [x] 중복 제거 로직 적용: 1차: 메모리 캐시(processed_ids)를 통한 중복 요청 방지, Kafka Log Compaction 활용을 위한 news_id (URL 해시) Key 설정
- [x] Kafka Producer 연동: 수집된 뉴스 데이터를 news-raw 토픽으로 전송
- [x] main.py 실행 시 cleanup.policy=delete,compact가 적용된 토픽 자동 생성 로직 추가
- [x] docker-compose.yml에 producer-news 서비스 추가 및 Volume 마운트 설정
- [x] Google RSS 사용에 대한 이유, Kafka Compact 및 중복처리 2단계 구조에 대한 내용을 정리하여 기술개발 문서에 추가했습니다.

## 🔍 관련 이슈
- [I-21](https://github.com/gAemI-AI/gAemI-AI/issues/21)

## 🙏 To Reviewers
  - news-raw 토픽의 데이터 포맷이 [명세서 v1.1](https://www.notion.so/DATA-v1-1-2bc0c3d3c9ea80999f9ffb161d84b6e8?source=copy_link)과 일치하는지 확인부탁드립니다.
  - docker-compose up -d --build 후 localhost:8080 (kafka UI)에서 총 4개의 Topic이 정상적으로 생성되는지 확인 부탁드립니다. (단, 주식장이 마감되었을때는 일부 stock 관련 topic이 생성되지 않았을 수도 있으므로 news-raw가 생성되었는지 확인부탁드립니다.)
  - 뉴스 데이터 수집 주기는 60초로 설정하였습니다. (구글 차단 방지)

## 🔗 문서
<!-- 참고할 수 있는 자료(노션 정리 또는 공식 문서 등)를 입력하세요. -->
  - [명세서 v1.1](https://www.notion.so/DATA-v1-1-2bc0c3d3c9ea80999f9ffb161d84b6e8?source=copy_link)
- [왜 Google RSS를 사용했나요?](https://www.notion.so/Google-RSS-2c00c3d3c9ea803ca500d5374af9cdc1?source=copy_link)
- [중복방지를 위한 2단계 방어선 구축! In-Memory Filtering + Kafka Log Compaction](https://www.notion.so/2-In-Memory-Filtering-Kafka-Log-Compaction-2c00c3d3c9ea802eb722e7f050803e6c?source=copy_link)

## 🧪 테스트 방법
1. 노션 api key 문서의 .env 파일 다운로드 후 data-pjt 안에 저장
2. docker-compose up -d --build
3. (vscode내 로그 및 오류 확인) docker logs -f gaemi_producer_news
4. `localhost:8080`kafka UI 접속 후 Topic 생성 확인
5. news-raw topic 클릭 > Messages에서 데이터 형식 확인

## 📸 스크린샷/동작 확인
- 토픽 생성 결과 (현재는 장마감 후라 실시간 데이터가 들어오지 않은 몇개의 topic은 생성되지 않은 상태입니다.)
<img width="2239" height="407" alt="image" src="https://github.com/user-attachments/assets/47d7ae7c-f44b-482b-859c-26d17d0e12ec" />

- news-raw messages 확인
<img width="2231" height="707" alt="image" src="https://github.com/user-attachments/assets/daa42fd9-1aca-4fd2-aade-c7d3a18e9ef8" />

- vscode내 로그 및 오류 확인
<img width="998" height="397" alt="image" src="https://github.com/user-attachments/assets/3e6dc2b6-fbcc-4895-b2b2-3ab94ee08c8e" />