### PR TITLE
[I-29] 실시간 주식 등락 및 뉴스 알림 처리 Flink Job 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [왜 Google RSS를 사용했나요?](https://www.notion.so/Google-RSS-2c00c3d3c9ea803ca500d5374af9cdc1?source=copy_link)
 - [중복방지를 위한 2단계 방어선 구축! In-Memory Filtering + Kafka Log Compaction](https://www.notion.so/2-In-Memory-Filtering-Kafka-Log-Compaction-2c00c3d3c9ea802eb722e7f050803e6c?source=copy_link)
 - [왜 기사 전체 내용을 Embedding 변환하지 않았나요?](https://www.notion.so/Embedding-2c60c3d3c9ea8049b09af74c3625ebe4?source=copy_link)
+- [Flink 알림 시스템: 이상(Broadcast)과 현실의 간극 좁히기](https://www.notion.so/Flink-Broadcast-2cc0c3d3c9ea80cca4efdd88189fbc67?source=copy_link)
 
 ## 📌 Git 협업 전략
 -

--- a/gaemi-project/data-pjt/flink-jobs/config.py
+++ b/gaemi-project/data-pjt/flink-jobs/config.py
@@ -1,24 +1,39 @@
 # data-pjt/flink-jobs/config.py
-# # 설정 관리: config.py
+# 설정 관리: config.py
 
 import os
 
 # Kafka 설정
 KAFKA_BROKER = "kafka:29092"
 TOPIC_NEWS_RAW = "news-raw"
+TOPIC_STOCK_TICKS = "stock-ticks"
+TOPIC_ALERT = "alert"  # 알림 전송용 토픽
 GROUP_ID = "flink-news-rag-group"
+GROUP_ID_NOTIFICATION = "flink-notification-group"
 
 # ElasticSearch 설정
 ES_HOST = "http://elasticsearch:9200"
 INDEX_NEWS_SUMMARY = "news-summary"
+INDEX_STOCK_RAWS = "stock-raws"  
 
 # OpenAI 설정 (.env 파일로 주입 받기)
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") 
+OPENAI_MODEL = os.getenv("OPENAI_MODEL")
+
+# PostgreSQL 설정
+POSTGRES_HOST = os.getenv("POSTGRES_HOST", "db")
+POSTGRES_PORT = os.getenv("POSTGRES_PORT", "5432")
+POSTGRES_DB = os.getenv("POSTGRES_DB", "gaemi_ai")
+POSTGRES_USER = os.getenv("POSTGRES_USER", "gaemi")
+POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD", "gaemigaemi11")
+
+# PostgreSQL 연결 URL
+POSTGRES_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
 
 # 배치 처리 설정
 BATCH_WINDOW_SECONDS = 5  # 5초마다 모아서 처리 (수정 가능)
 BATCH_SIZE_THRESHOLD = 10 # 10개 모이면 처리 (수정 가능)
 
-# .env에 있는 값 불러오기
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY") 
-OPENAI_MODEL = os.getenv("OPENAI_MODEL")
+# 알림 설정
+RULE_RELOAD_INTERVAL_SECONDS = 60  # 1분마다 규칙 재로딩
+ALERT_COOLDOWN_SECONDS = 300  # 5분 쿨타임 (같은 규칙 중복 방지)

--- a/gaemi-project/data-pjt/flink-jobs/mock_producer.py
+++ b/gaemi-project/data-pjt/flink-jobs/mock_producer.py
@@ -1,0 +1,79 @@
+import json
+import time
+import random
+import sys
+import os
+from datetime import datetime
+
+# config.py 경로 인식을 위해 추가
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from kafka import KafkaProducer
+from kafka.errors import NoBrokersAvailable
+from config import KAFKA_BROKER, TOPIC_STOCK_TICKS
+
+def run_mock_producer():
+    print(f"🚀 [Mock] 가짜 주식 데이터 생성기 시작")
+    print(f"👉 Target Kafka: {KAFKA_BROKER}")
+    print(f"👉 Target Topic: {TOPIC_STOCK_TICKS}")
+
+    producer = None
+    
+    # 1. Kafka 연결 시도
+    for i in range(10):
+        try:
+            producer = KafkaProducer(
+                bootstrap_servers=KAFKA_BROKER,
+                value_serializer=lambda v: json.dumps(v).encode('utf-8')
+            )
+            print("✅ Kafka 연결 성공!")
+            break
+        except NoBrokersAvailable:
+            print(f"⏳ Kafka 연결 대기 중... ({i+1}/10)")
+            time.sleep(2)
+    
+    if not producer:
+        print("❌ Kafka 연결 실패. 종료합니다.")
+        return
+
+    # 2. 가짜 데이터 무한 발송
+    stock_list = [
+        {"code": "005930", "name": "삼성전자", "base_price": 75000},
+        {"code": "000660", "name": "SK하이닉스", "base_price": 140000},
+        {"code": "035420", "name": "NAVER", "base_price": 210000},
+    ]
+
+    try:
+        while True:
+            for stock in stock_list:
+                # 가격 변동 (랜덤)
+                fluctuation = random.randint(-1000, 1000)
+                current_price = stock["base_price"] + fluctuation
+                
+                data = {
+                    "stock_code": "005930",
+                    "stock_name": "삼성전자",
+                    "current_price": 75000,
+                    "timestamp": datetime.now().isoformat(),
+                    # 👇 아래 필드들이 빠져서 경고가 뜨는 것임! (0이라도 넣어야 함)
+                    "diff": 1000,
+                    "rate": 1.5,
+                    "open_price": 74000,
+                    "high_price": 75500,
+                    "low_price": 73500,
+                    "tick_volume": 100,
+                    "accumulated_vol": 500000
+                    }
+                
+                producer.send(TOPIC_STOCK_TICKS, value=data)
+                print(f"📤 [Sent] {stock['name']}({stock['code']}): {current_price}원")
+            
+            producer.flush()
+            time.sleep(2) # 2초마다 발송
+
+    except KeyboardInterrupt:
+        print("\n🛑 중단됨")
+        producer.close()
+
+if __name__ == "__main__":
+    run_mock_producer()

--- a/gaemi-project/data-pjt/flink-jobs/notification_processor.py
+++ b/gaemi-project/data-pjt/flink-jobs/notification_processor.py
@@ -1,0 +1,164 @@
+# data-pjt/flink-jobs/notification_processor.py
+# 실시간 주식 알림 처리: kafka에서 실시간 주가를 받아 사용자가 설정한 알림 조건(DB)과 비교 후 알림 발송
+
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors.kafka import KafkaSource, KafkaOffsetsInitializer, KafkaSink, KafkaRecordSerializationSchema
+from pyflink.common.serialization import SimpleStringSchema
+from pyflink.common import WatermarkStrategy, RestartStrategies
+from pyflink.datastream.functions import MapFunction 
+from pyflink.common.typeinfo import Types
+
+import json
+import time
+from datetime import datetime
+import sys
+import os
+
+# Docker 컨테이너 내 로컬 모듈(config, utils)를 찾기 위한 경로 설정
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# 사용자 정의 모듈 import
+from config import (
+    KAFKA_BROKER, TOPIC_STOCK_TICKS, TOPIC_ALERT, 
+    GROUP_ID_NOTIFICATION, RULE_RELOAD_INTERVAL_SECONDS, ALERT_COOLDOWN_SECONDS
+)
+from utils.db_connector import load_active_rules, save_triggered_notification, check_recent_alert
+
+class NotificationProcessor(MapFunction):
+    def __init__(self):
+        self.rules = [] # DB에서 가져온 알림 규칙을 저장할 리스트 (메모리 캐시)
+        self.last_load_time = 0 # 마지막으로 규칙을 로딩한 시간 (주기적 갱신)
+        self.reload_interval = RULE_RELOAD_INTERVAL_SECONDS # 규칙 갱신 시간 
+
+    def open(self, runtime_context):
+        """
+        생명주기: Job이 시작될 때 한 번 실행되는 함수, 데이터 처리를 시작하지 전에 DB에서 초기 규칙 미리 로딩
+        """
+        print("[Processor] Worker 시작 및 규칙 로딩")
+        self._load_rules()
+    
+    def _load_rules(self):
+        """
+        도우미: DB에서 활성화된 알림 규칙을 가져와서 메모리에 저장
+        """
+        try:
+            self.rules = load_active_rules() # db_connector.py의 함수 호출
+            self.last_load_time = time.time() # 로딩 시간 기록
+            print(f"[Rules] 현재 활성 규칙: {len(self.rules)}개")
+            sys.stdout.flush() # 로그 즉시 출력
+        except Exception as e:
+            print(f"❌ [Rules Load Error] {e}")
+            sys.stdout.flush()
+    
+    def map(self, value):
+        """
+        메인 함수: Kafka에서 데이터가 들어올 때 마다 실행됨
+        e.g., value: '{'stock_code': "005930", 'current_price': 75000}'
+        """
+        try:
+            # 1. 규칙 갱신 주기 체크: 규칙 갱신 시간이 지났으면 DB에서 다시 로드
+            if time.time() - self.last_load_time > self.reload_interval:
+                self._load_rules()
+            
+            # 2. 들어온 문자열 데이터 JSON으로 변환
+            stock_data = json.loads(value)
+            stock_code = stock_data.get('stock_code')
+            price = float(stock_data.get('current_price', 0))
+            
+            if not stock_code or price == 0: return None # 데이터가 비정상이면 None 반환 (나중에 filter로 걸러짐)
+            
+            # 3. 메모리에 있는 모든 알림 규칙을 하나씩 검사 (순회)
+            for rule in self.rules:
+                # 규칙의 종목코드와 현재 들어온 주식 종목코드가 다르면 패스
+                if rule['stock_id'] != stock_code: continue
+                
+                # 조건 비교 준비
+                target = float(rule['target_value'])
+                op = rule['operator']
+
+                # 4. 실제 가격 비교 로직
+                is_triggered = (op == '>=' and price >= target) or \
+                               (op == '<=' and price <= target) or \
+                               (op == '==' and abs(price - target) < 0.01)
+                
+                # 5. 조건이 만족되었다면 -> 알림 발생
+                if is_triggered:
+                    # 최근 5분(300초) 내에 이미 알림을 보냈는지 확인
+                    if check_recent_alert(rule['rule_id'], ALERT_COOLDOWN_SECONDS):
+                        print(f"      쿨타임 중: {rule['stock_name']}")
+                        continue
+                    
+                    # 알림 메시지 생성
+                    msg = f"[알림] {rule['stock_name']} {op} {target:,.0f}원 도달! (현재: {price:,.0f}원)"
+                    
+                    # 6. DB에 알림 발송 내역 저장 (성공 시 알림 ID 반환)
+                    noti_id = save_triggered_notification(rule['user_id'], rule['stock_name'], msg)
+                    
+                    if noti_id:
+                        print(f"    [알림 발송 & DB 저장 완료] ID: {noti_id}")
+                        sys.stdout.flush()
+
+                        # 7. kafka 'alert' 토픽으로 보낼 데이터 반환 (이 반환값은 main 함수 sink로 전달됨)
+                        return json.dumps({
+                            'notification_id': noti_id,
+                            'user_id': rule['user_id'],
+                            'message': msg,
+                            'timestamp': datetime.now().isoformat()
+                        }, ensure_ascii=False)
+            return None # 맞는 규칙이 하나도 없으면 None 반환
+        
+        except Exception as e:
+            print(f"❌ [Process Error] {e}")
+            sys.stdout.flush()
+            return None
+
+# -----------------------------------------------------------
+# 메인 함수 (Flink Job 토폴로지 정의)
+# : 전체 파이프라인(Source -> Process -> Sink)을 조립
+# -----------------------------------------------------------
+def main():
+    # 1. 실행 환경 생성
+    env = StreamExecutionEnvironment.get_execution_environment()
+    env.set_parallelism(1) # 순서 보장을 위해 병렬 처리를 1개로 제한
+    
+    # 에러가 나면 5초(5000ms) 쉬었다가 최대 100번까지 재시작
+    # DB가 잠깐 끊기거나 Kafka가 늦게 뜰 때 죽지 않도록 함
+    env.set_restart_strategy(RestartStrategies.fixed_delay_restart(
+        100,  # 최대 100번 재시도
+        5000  # 5000ms 대기
+    ))
+
+    # 2. Source 설정
+    # -> Kafka의 'stock-ticks' 토픽에서 데이터를 읽어옴
+    stock_source = KafkaSource.builder() \
+        .set_bootstrap_servers(KAFKA_BROKER) \
+        .set_topics(TOPIC_STOCK_TICKS) \
+        .set_group_id(GROUP_ID_NOTIFICATION) \
+        .set_starting_offsets(KafkaOffsetsInitializer.latest()) \
+        .set_value_only_deserializer(SimpleStringSchema()) \
+        .build()
+    
+    # 3. Sink 설정
+    # -> 처리된 알림을 Kafka의 'alert' 토픽으로 보냄
+    alert_sink = KafkaSink.builder() \
+        .set_bootstrap_servers(KAFKA_BROKER) \
+        .set_record_serializer(
+            KafkaRecordSerializationSchema.builder()
+            .set_topic(TOPIC_ALERT)
+            .set_value_serialization_schema(SimpleStringSchema())
+            .build()
+        ) \
+        .build()
+    
+    # 4. 파이프라인 연결 (Data Flow)
+    env.from_source(stock_source, WatermarkStrategy.no_watermarks(), "Stock Source") \
+        .map(NotificationProcessor(), output_type=Types.STRING()) \
+        .filter(lambda x: x is not None) \
+        .sink_to(alert_sink)
+
+    print("🚀 Flink Job Started...")
+    sys.stdout.flush()
+    env.execute("Notification Job")
+
+if __name__ == "__main__":
+    main()

--- a/gaemi-project/data-pjt/flink-jobs/setup_kafka.py
+++ b/gaemi-project/data-pjt/flink-jobs/setup_kafka.py
@@ -1,0 +1,54 @@
+# data-pjt/flink-jobs/setup_kafka.py
+# Flink Job이 시작되기 전, Kafka 브로커가 살아있는지 확인 후
+# 필요한 토픽들을 미리 생성하는 초기화 스크립트
+
+import time
+import sys
+from kafka.admin import KafkaAdminClient, NewTopic
+from kafka.errors import NoBrokersAvailable, TopicAlreadyExistsError
+
+KAFKA_BROKER = "gaemi_kafka:29092"
+REQUIRED_TOPICS = ["stock-ticks", "stock-orderbook", "index-ticks", "alert"]
+
+def wait_for_kafka_and_init():
+    print(f"🛠️ [Setup] Kafka({KAFKA_BROKER}) 연결 및 토픽 생성 시도...")
+    
+    admin_client = None
+    max_retries = 30  # 최대 30번 시도
+    
+    for i in range(max_retries):
+        try:
+            # 1. 연결 시도
+            admin_client = KafkaAdminClient(bootstrap_servers=KAFKA_BROKER) # 실패 시 바로 except(NoBrokersAvailable)로 감
+            print("✅ [Setup] Kafka 연결 성공!")
+            
+            # 2. 토픽 생성
+            existing_topics = admin_client.list_topics()
+            new_topics = []
+            
+            for topic in REQUIRED_TOPICS:
+                if topic not in existing_topics:
+                    new_topics.append(NewTopic(name=topic, num_partitions=1, replication_factor=1))
+            
+            if new_topics:
+                admin_client.create_topics(new_topics)
+                print(f"✨ [Setup] 새 토픽 생성 완료: {len(new_topics)}개")
+            else:
+                print("👍 [Setup] 모든 토픽이 이미 존재합니다.")
+                
+            admin_client.close()
+            return True # 성공
+            
+        except NoBrokersAvailable:
+            print(f"⏳ [Setup] Kafka 부팅 대기 중... ({i+1}/{max_retries})")
+            time.sleep(2)
+        except Exception as e:
+            print(f"⚠️ [Setup] 예기치 않은 오류 (재시도 함): {e}")
+            time.sleep(2)
+    
+    print("❌ [Setup] Kafka 연결 실패 (Timeout)")
+    return False # 실패
+
+if __name__ == "__main__":
+    if not wait_for_kafka_and_init():
+        sys.exit(1) # 실패 시 컨테이너 종료 코드로 빠져나감

--- a/gaemi-project/data-pjt/flink-jobs/stock_raw_ingest.py
+++ b/gaemi-project/data-pjt/flink-jobs/stock_raw_ingest.py
@@ -5,6 +5,7 @@ from pyflink.common.watermark_strategy import WatermarkStrategy
 
 import json
 import requests
+import time
 
 
 def save_to_elasticsearch(record):
@@ -49,22 +50,28 @@ def run():
     env = StreamExecutionEnvironment.get_execution_environment()
     env.set_parallelism(1)
 
-    # # 꼭 필요
-    # env.add_jars(
-    #     "file:///opt/flink/lib/flink-connector-kafka-1.17.1.jar",
-    #     "file:///opt/flink/lib/kafka-clients-3.5.1.jar"
-    # )
-
-    # 데이터 수도꼭지 틀기
-    source = (
-        KafkaSource.builder()
-        .set_bootstrap_servers("kafka:29092")
-        .set_topics("stock-ticks")                       # ← topic 정확히 이 이름
-        .set_group_id("flink-stock-consumer-debug-1")    # ← 새 group id
-        .set_starting_offsets(KafkaOffsetsInitializer.earliest())  # ← 토픽 처음부터
-        .set_value_only_deserializer(SimpleStringSchema())
-        .build()
-    )
+    # Kafka 연결 재시도 로직
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            print(f"[KAFKA] 연결 시도 {attempt + 1}/{max_retries}")
+            source = (
+                KafkaSource.builder()
+                .set_bootstrap_servers("kafka:29092")
+                .set_topics("stock-ticks")                       # ← topic 정확히 이 이름
+                .set_group_id("flink-stock-consumer-debug-1")    # ← 새 group id
+                .set_starting_offsets(KafkaOffsetsInitializer.earliest())  # ← 토픽 처음부터
+                .set_value_only_deserializer(SimpleStringSchema())
+                .build()
+            )
+            print("[KAFKA] ✅ 연결 성공")
+            break
+        except Exception as e:
+            print(f"[KAFKA] ❌ 연결 실패: {e}")
+            if attempt < max_retries - 1:
+                time.sleep(5)
+            else:
+                raise
 
     stream = env.from_source(
         source,

--- a/gaemi-project/data-pjt/flink-jobs/utils/db_connector.py
+++ b/gaemi-project/data-pjt/flink-jobs/utils/db_connector.py
@@ -1,0 +1,158 @@
+# data-pjt/flink-jobs/utils/db_connector.py
+# Flink Job이 PostgreSQL DB에 접속해서 데이터를 쓰거나 읽는 모듈 모음
+# - (안정성) DB 연결 실패시 재시도 로직 포함
+# - (편의성) 데이터 조회 결과 JSON 변환
+# - (데이터 무결성) 트랜잭션 관리(commit/rollback) 확실하게 처리
+
+import psycopg2
+from psycopg2.extras import RealDictCursor
+from datetime import datetime, timedelta
+import time
+import sys
+
+from config import POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB, POSTGRES_USER, POSTGRES_PASSWORD
+
+# DB 연결 및 객체 반환 함수
+def get_db_connection(max_retries=3, retry_delay=2):
+    """
+    PostgreSQL 연결 객체 반환 
+    - 디폴트 3번까지 재시도
+    """
+    for attempt in range(max_retries):
+        try:
+            conn = psycopg2.connect(
+                host=POSTGRES_HOST,
+                port=POSTGRES_PORT,
+                dbname=POSTGRES_DB,
+                user=POSTGRES_USER,
+                password=POSTGRES_PASSWORD
+            )
+            return conn
+        
+        except Exception as e:
+            print(f"⚠️ [DB Connect Fail] {e} (시도 {attempt + 1}/{max_retries})")
+            sys.stdout.flush() # 로그 즉시 출력
+            
+            # 마지막 시도가 아니면 잠시 기다렸다 다시 시도
+            if attempt < max_retries - 1:
+                time.sleep(retry_delay)
+    
+    print("❌ [DB] 연결 실패")
+    sys.stdout.flush()
+    return None
+
+
+# 알림 규칙 로딩 함수
+def load_active_rules():
+    """
+    DB에서 활성화된 알림 규칙 모두 조회
+    NotificationProcessor가 시작될 때 + 주기적으로 호출
+    """
+    conn = get_db_connection()
+    # 연결 객체 없으면 빈 리스트 반환
+    if not conn: return []
+    
+    try:
+        # cursor_factory=RealDictCursor: 결과를 딕셔너리로 받기 (JSON)
+        with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+            query = """
+                SELECT 
+                    nr.rule_id, nr.user_id, nr.target_value, nr.operator, nr.metric_type,
+                    sm.stock_id, sm.stock_name
+                FROM user_notification_rules nr
+                JOIN stock_master sm ON nr.stock_id = sm.stock_id
+                WHERE nr.is_active = TRUE
+            """
+            cursor.execute(query)
+            rules = cursor.fetchall() # 모든 결과 가져오기
+            
+            print(f"[DB] 활성 규칙 {len(rules)}개 로딩 완료")
+            sys.stdout.flush()
+            return [dict(rule) for rule in rules]
+            
+    except Exception as e:
+        print(f"❌ [DB Load Rules Error] {e}")
+        sys.stdout.flush()
+        return []
+    
+    # 실패 성공과 상관없이 DB 연결 해제
+    finally:
+        if conn: conn.close()
+
+# 알림 결과 저장 함수
+def save_triggered_notification(user_id, stock_name, message):
+    """
+    조건이 만족되어 알람이 발생한 경우 그 내역을 DB에 저장
+    - 저장이 되어야 프론트엔드 알림함에 뜸
+    """
+    conn = get_db_connection()
+
+    if not conn: return None
+    
+    try:
+        with conn.cursor() as cursor:
+            # INSERT 쿼리: 알림 내역 테이블에 데이터 추가
+            query = """
+                INSERT INTO triggered_notifications 
+                (user_id, stock_name, message, is_read, triggered_at)
+                VALUES (%s, %s, %s, FALSE, NOW())
+                RETURNING notification_id
+            """
+            cursor.execute(query, (user_id, stock_name, message))
+
+            # 방금 생성된 ID 받아오기
+            notification_id = cursor.fetchone()[0]
+            conn.commit() # 커밋으로 DB 저장
+            
+            print(f"[DB] 알림 저장 완료 - ID: {notification_id}")
+            sys.stdout.flush()
+            return notification_id 
+            
+    except Exception as e:
+        print(f"❌ [DB Save Notification Error] {e}")
+        sys.stdout.flush()
+        conn.rollback() # 에러나면 작업 취소 (되돌리기)
+        return None
+    
+    # 성공 실패와 상관없이 연결 해제
+    finally:
+        if conn: conn.close()
+
+
+# 중복 알림 방지
+def check_recent_alert(rule_id, cooldown_seconds=300):
+    """
+    해당 규칙(rule_id)으로 최근 5분(300초) 내에 알람을 보낸 이력이 있는지 확인
+    - 주가가 왔다갔다 할때 알림 폭탄을 막기 위해 
+    """
+    conn = get_db_connection()
+    if not conn: return False # DB 연결 안 되면 일단 알림 보내도록 False 반환
+    
+    try:
+        with conn.cursor() as cursor:
+            # 1. 시간 계산: 현재 시간에서 5분을 뺀 시간을 구함
+            # SQL 문법(INTERVAL) 에러를 피하기 위해 파이썬에서 계산해서 넘김
+            limit_time = datetime.now() - timedelta(seconds=cooldown_seconds)
+            
+            # 2. 조회 쿼리:
+            # 메시지 내용에 식별자가 포함되어 있고,
+            # 발생 시간이 limit_time보다 최신인 데이터가 몇 개인지 셈
+            query = """
+                SELECT COUNT(*) 
+                FROM triggered_notifications
+                WHERE message LIKE %s
+                  AND triggered_at > %s
+            """
+            cursor.execute(query, (f'%규칙#{rule_id}%', limit_time))
+            count = cursor.fetchone()[0]
+            
+            # 개수가 0보다 크면 = 최근에 보낸 적이 있다 (True)
+            return count > 0
+            
+    except Exception as e:
+        print(f"⚠️ [DB Cooldown Check Error] {e}")
+        sys.stdout.flush()
+        return False
+    # 성공 실패와 상관없이 연결 해제
+    finally:
+        if conn: conn.close()

--- a/gaemi-project/data-pjt/flink/Dockerfile-flink
+++ b/gaemi-project/data-pjt/flink/Dockerfile-flink
@@ -7,10 +7,9 @@ RUN apt-get update --fix-missing && \
     apt-get install -y --fix-missing python3 python3-pip && \
     ln -s /usr/bin/python3 /usr/bin/python
 
-# 2. PyFlink 및 필요한 라이브러리 설치 (문법 수정됨)
-# 한 줄로 이어지도록 && \ 를 사용하여 연결했습니다.
+# 2. PyFlink 및 필요한 라이브러리 설치
 RUN python3 -m pip install --upgrade pip && \
-    python3 -m pip install "apache-flink==1.18.1" requests protobuf beautifulsoup4 openai tiktoken
+    python3 -m pip install "apache-flink==1.18.1" requests protobuf beautifulsoup4 openai tiktoken psycopg2-binary
     
 WORKDIR /opt/flink
 

--- a/gaemi-project/data-pjt/flink/flink-sql-connector-elasticsearch-7-3.0.1-1.17.jar
+++ b/gaemi-project/data-pjt/flink/flink-sql-connector-elasticsearch-7-3.0.1-1.17.jar
@@ -1,0 +1,16 @@
+<html>
+<head><title>404 Not Found</title></head>
+<body bgcolor="white">
+<center><h1>404 Not Found</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+<!-- a padding to disable MSIE and Chrome friendly error page -->
+
+
+

--- a/gaemi-project/docker-compose.yml
+++ b/gaemi-project/docker-compose.yml
@@ -190,7 +190,7 @@ services:
     command: taskmanager
     environment:
       - JOB_MANAGER_RPC_ADDRESS=flink-jobmanager # jobManager 명시
-      - TASK_MANAGER_NUMBER_OF_TASK_SLOTS=2 # 동시에 처리할 작업 수
+      - TASK_MANAGER_NUMBER_OF_TASK_SLOTS=4 # 동시에 처리할 작업 수
       - PYTHONPATH=/opt/flink/usrlib/jobs
     depends_on:
       - flink-jobmanager
@@ -233,7 +233,7 @@ services:
         echo '✅ JobManager 응답 확인' &&
         
         echo '[Submit] 1️⃣ 실시간 알림 Job 제출...' &&
-        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/notification_processor_v2.py || echo '❌ Job 1 제출 실패' &&
+        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/notification_processor.py || echo '❌ Job 1 제출 실패' &&
         sleep 5 &&
         
         echo '[Submit] 2️⃣ 뉴스 AI 분석 Job 제출...' &&

--- a/gaemi-project/docker-compose.yml
+++ b/gaemi-project/docker-compose.yml
@@ -2,45 +2,45 @@
 version: '3.8'
 
 services:
-  # 네트워크 내에서 'db'로 호출 가능
   # 1. DB 서비스
   db:
     image: postgres:15
     container_name: gaemi_db
-    restart: always
-
+    restart: always # 죽으면 계속 다시 살림
     environment:
       POSTGRES_USER: gaemi
       POSTGRES_PASSWORD: gaemigaemi11 
       POSTGRES_DB: gaemi_ai
-
     ports:
       - "5432:5432"
-
     volumes:
-      # (영속성) 컨테이너 삭제되어도 데이터를 볼륨에 안전하게 보관
       - postgres_data:/var/lib/postgresql/data
-      # (초기화) 컨테이너가 처음 생성될 때, 자동으로 .sql 파일 실행
       - ./config/postgres/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-      # 현재 폴더의 'data' 디렉토리 -> 컨테이너 내부 '/docker-data' 디렉토리로 연결
       - ./config/postgres/data:/docker-data
+    # 헬스체크: DB가 실제로 접속 가능한 상태인지 검사
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U gaemi -d gaemi_ai"]
+      interval: 10s # 10초 간격으로
+      timeout: 5s
+      retries: 5
 
   # 2. 백엔드 서비스
   backend:
     build:
-      context: ./backend-pjt
+      context: ./backend-pjt # 해당 폴더 내 Dockerfile로 이미지 빌드
     container_name: gaemi_backend
     ports:
       - "8000:8000"
     volumes:
-      - ./backend-pjt:/app
+      - ./backend-pjt:/app # 코드 수정시 재시작 없이 바로 반영되도록 연결
     environment:
       - POSTGRES_DB=gaemi_ai
       - POSTGRES_USER=gaemi
       - POSTGRES_PASSWORD=gaemigaemi11
       - POSTGRES_HOST=db
     depends_on:
-      - db
+      db:
+        condition: service_healthy # DB 켜짐 + 접속 가능 상태까지 대기 후 실행
   
   # 3. 프론트엔드 서비스
   frontend:
@@ -48,16 +48,17 @@ services:
       context: ./frontend-pjt
     container_name: gaemi_front
     ports:
-      - "5173:5173"   # Vite 기본 포트
+      - "5173:5173"
     volumes:
-      - ./frontend-pjt:/app
-      - /app/node_modules # 호스트의 node_modules 동기화 방지
+      - ./frontend-pjt:/app # 로컬 소스를 컨테이너로 공유
+      - /app/node_modules # (익명 볼륨) 컨테이너 내부 전용 공간: 로컬의 node_modules와 섞이지 않게 컨테이너 전용으로 격리
+      # 격리하지 않을시: npm install때마다 로컬, 컨테이너 node_modules가 깨짐. CI 환경에서 재현 불가
     working_dir: /app
-    command: ["npm", "run", "dev", "--", "--host"] 
+    command: ["npm", "run", "dev", "--", "--host"] # 외부 접속 허용하며 실행
     depends_on:
       - backend
   
-  # 4. zookeeper (Kafka 관리자)
+  # 4. zookeeper: kafka 브로커 관리 및 조율
   zookeeper:
     image: confluentinc/cp-zookeeper:7.6.0
     container_name: gaemi_zookeeper
@@ -69,7 +70,7 @@ services:
     volumes:
       - zookeeper_data:/var/lib/zookeeper/data
 
-  # 5. kafka 
+  # 5. kafka: 메시지 브로커
   kafka:
     image: confluentinc/cp-kafka:7.6.0
     container_name: gaemi_kafka
@@ -78,13 +79,12 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-     # [네트워크 설정]
-      # - 내부 통신 (Producer->Kafka): kafka:29092
-      # - 외부 접속 (Host->Kafka): localhost:9092
+      # 접속 주소 설정 -> 틀리면 Connection Refused남
+      # - PLAINTEXT: Docker 내부끼리 통신할 때 (kafka:29092)
+      # - PLAINTEXT_HOST: 내 컴퓨터에서 접속할 때 (localhost:9092)
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      # 싱글 노드 필수 설정
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
@@ -92,8 +92,14 @@ services:
       - zookeeper
     volumes:
       - kafka_data:/var/lib/kafka/data
+    # kafka는 무거워서 부팅이 느림 -> 그때마다 쌓이는 에러 로그를 막기 위해 설정
+    healthcheck:
+      test: nc -z localhost 9092 || exit 1
+      interval: 10s
+      timeout: 10s
+      retries: 10
 
-  # 6. Kafka UI 서비스
+  # 6. Kafka UI
   kafka-ui:
     image: provectuslabs/kafka-ui:latest
     container_name: gaemi_kafka_ui
@@ -106,7 +112,7 @@ services:
     depends_on:
       - kafka
 
-  # 7. (kafka) 주식 데이터 수집기 (Producer)
+  # 7. 주식 데이터 수집기 (Producer) - 독립 실행
   producer-stock:
     build:
       context: ./data-pjt/producer-stock
@@ -118,10 +124,11 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy # kafka가 'Healthy'상태가 될 때까지 기다렸다 실행 (DNS 에러 방지)
     restart: on-failure
 
-  # 8. (kafka) 뉴스 데이터 수집기 (Producer2)
+  # 8. 뉴스 데이터 수집기
   producer-news:
     build:
       context: ./data-pjt/producer-news
@@ -134,58 +141,80 @@ services:
       - kafka
     restart: on-failure
 
-   # 9. Flink JobManager
+  # 9. Flink JobManager: 토픽 자동 생성만 수행 (매니저 역할)
   flink-jobmanager:
     build:
       context: ./data-pjt/flink
       dockerfile: Dockerfile-flink
     image: gaemi-flink-jobmanager:1.18
-    platform: linux/amd64  # 추가
+    platform: linux/amd64
     container_name: gaemi_flink_jobmanager
     ports:
-      - "8081:8081"   # Flink Web UI
-    command: jobmanager
+      - "8081:8081"
     environment:
       - JOB_MANAGER_RPC_ADDRESS=flink-jobmanager
       - PYTHONPATH=/opt/flink/usrlib/jobs
     depends_on:
-      - kafka
+      kafka:
+        condition: service_started
+      db:
+        condition: service_healthy
     volumes:
       - ./data-pjt/flink-jobs:/opt/flink/usrlib/jobs
       - ./data-pjt/flink/flink-connector-kafka-3.2.0-1.18.jar:/opt/flink/lib/flink-connector-kafka-3.2.0-1.18.jar
       - ./data-pjt/flink/kafka-clients-3.5.1.jar:/opt/flink/lib/kafka-clients-3.5.1.jar
     env_file:
       - ./data-pjt/flink-jobs/.env
+    # 컨테이너가 켜진 뒤 실행할 명령어를 자동 생성
+    # 1. pip install: 필요한 라이브러리 설치
+    # 2. setup_kafka.py: 토픽(stock-ticks 등)이 없으면 만들고 올 때까지 대기
+    # 3. jobmanager: 모든 준비가 끝나면 Flink 실행
+    command: >
+      bash -c "
+        echo '[job-manager] Kafka 라이브러리 설치...' &&
+        pip install kafka-python && 
+        echo '[job-manager] 토픽 생성 스크립트 실행...' &&
+        python /opt/flink/usrlib/jobs/setup_kafka.py &&
+        echo '===토픽 자동 생성 완료 JobManager 시작===' &&
+        /docker-entrypoint.sh jobmanager
+      "
 
-  # 10. Flink TaskManager
+  # 10. Flink TaskManager: JobManager가 시키는 Filtering, Mapping 등 실제 수행
   flink-taskmanager:
     build:
-      context: ./data-pjt/flink # JobMagaer랑 통일 / Job, Task Manager는 역할만 다르고 똑같은 소프트웨어 -> 둘 다 같은 파이썬 버전, 라이브러리, kafka 커넥트를 가지고 있어야함
+      context: ./data-pjt/flink
       dockerfile: Dockerfile-flink
-    platform: linux/amd64  # 추가
+    platform: linux/amd64
     image: gaemi-flink-taskmanager:1.18
     container_name: gaemi_flink_taskmanager
     command: taskmanager
     environment:
-      - JOB_MANAGER_RPC_ADDRESS=flink-jobmanager
-      - TASK_MANAGER_NUMBER_OF_TASK_SLOTS=2
+      - JOB_MANAGER_RPC_ADDRESS=flink-jobmanager # jobManager 명시
+      - TASK_MANAGER_NUMBER_OF_TASK_SLOTS=2 # 동시에 처리할 작업 수
       - PYTHONPATH=/opt/flink/usrlib/jobs
     depends_on:
       - flink-jobmanager
     volumes:
-      - ./data-pjt/flink-jobs:/opt/flink/usrlib/jobs # TaskManager도 코드를 알아야함 -> 볼륨 마운트 필수
+      - ./data-pjt/flink-jobs:/opt/flink/usrlib/jobs
       - ./data-pjt/flink/flink-connector-kafka-3.2.0-1.18.jar:/opt/flink/lib/flink-connector-kafka-3.2.0-1.18.jar
       - ./data-pjt/flink/kafka-clients-3.5.1.jar:/opt/flink/lib/kafka-clients-3.5.1.jar
     env_file:
       - ./data-pjt/flink-jobs/.env
   
-  # 11. Job 자동 제출기 (일회용)
+  # 11. Job 자동 제출기: job 등록 자동화
   flink-job-submitter:
-    image: gaemi-flink-jobmanager:1.18  # 기존 이미지 재사용
+    image: gaemi-flink-jobmanager:1.18
     platform: linux/amd64
     container_name: gaemi_job_submitter
     depends_on:
-      - flink-jobmanager
+      flink-jobmanager:
+        condition: service_started
+      flink-taskmanager:
+        condition: service_started
+      db:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
     env_file:
       - ./data-pjt/flink-jobs/.env
     environment:
@@ -196,14 +225,29 @@ services:
       - ./data-pjt/flink/kafka-clients-3.5.1.jar:/opt/flink/lib/kafka-clients-3.5.1.jar
     command: >
       /bin/sh -c "
-        echo '⏳ JobManager가 켜질 때까지 30초 대기...' &&
-        sleep 30 &&
-        echo '🚀 주가 데이터 수집 Job 제출' &&
-        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/stock_raw_ingest.py &&
-        echo '🚀 뉴스 AI 분석 Job 제출' &&
-        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/news_ai_analysis.py &&
-        echo '✅ 모든 Job 제출 완료!'"
-    restart: "no"  # 할 일 다 하면 꺼짐 (계속 재시작 방지)
+        echo '🔄 Flink 클러스터 부팅 대기 (60초)...' &&
+        sleep 60 &&
+        
+        echo '📡 JobManager 연결 테스트...' &&
+        /opt/flink/bin/flink list -m flink-jobmanager:8081 || exit 1 &&
+        echo '✅ JobManager 응답 확인' &&
+        
+        echo '[Submit] 1️⃣ 실시간 알림 Job 제출...' &&
+        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/notification_processor_v2.py || echo '❌ Job 1 제출 실패' &&
+        sleep 5 &&
+        
+        echo '[Submit] 2️⃣ 뉴스 AI 분석 Job 제출...' &&
+        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/news_ai_analysis.py || echo '❌ Job 2 제출 실패' &&
+        sleep 5 &&
+
+        echo '[Submit] 3️⃣ raw stock 정보 Job 제출...' &&
+        /opt/flink/bin/flink run -m flink-jobmanager:8081 -d -py /opt/flink/usrlib/jobs/stock_raw_ingest.py || echo '❌ Job 3 제출 실패' &&
+        sleep 5 &&
+        
+        echo '✅ 모든 Job 제출 완료!' &&
+        /opt/flink/bin/flink list -m flink-jobmanager:8081
+      "
+    restart: "no"
 
   # 12. Elasticsearch
   elasticsearch:
@@ -229,9 +273,9 @@ services:
     depends_on:
       - elasticsearch
 
-# Docker가 관리할 볼륨 정의
+# 볼륨 정의: 컨테이너가 꺼져도 사라지지 않는 외장하드
 volumes:
-  postgres_data:
+  postgres_data: # DB 데이터 저장
   zookeeper_data:
-  kafka_data:
-  esdata:
+  kafka_data: # Kafka 메시지 저장
+  esdata: # 검색 엔진 데이터 저장


### PR DESCRIPTION
## 📌 개요
실시간 주식 시세(stock-ticks) 스트림 데이터를 소비하여, 사용자가 설정한 알림 조건(user_notification_rules)과 매칭하고, 조건 충족 시 알림을 생성하여 저장 및 전송하는 Flink Job(notification_processor.py)을 구현했습니다.

## ✨ 주요 변경 사항
- [x] Notification Flink Job 구현: notification_processor.py 생성
- [x] 규칙 로딩 메커니즘: DB에서 사용자 알림 규칙을 주기적으로 로딩(Polling)하여 메모리에 캐싱하는 로직 구현
- [x] 알림 조건 검사 로직: 실시간 주가와 목표가를 비교(>=, <=)하여 조건 충족 여부 판별
- [x] 알림 데이터 처리: 조건 달성 시 triggered_notifications 테이블에 저장(INSERT) 후, 생성된 ID를 포함하여 Kafka alert 토픽으로 전송
- [x] 타입 안정성 확보: PyFlink 직렬화 이슈(ClassCastException) 해결을 위해 output_type=Types.STRING() 명시

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [I-29](https://github.com/gAemI-AI/gAemI-AI/issues/29)

## 🙏 To Reviewers
이번 구현에서는 초기 기획(Broadcast State, 병렬 Sink)과 달리 현실적인 효율성과 데이터 정합성을 위해 구조를 변경했습니다. 이 부분 중점적으로 봐주세요.
1. roadcast State 대신 MapFunction 캐싱 사용
- 현재 parallelism=1로 동작하므로 복잡한 Broadcast 패턴 대신, MapFunction 내에서 주기적으로 DB를 조회하여 메모리에 규칙을 캐싱하는 방식(Polling)을 택했습니다. 구현 복잡도를 낮추고 유지보수성을 높였습니다.
2. 순차적 Sink 처리 (DB → Kafka)
- 알림 메시지를 Kafka로 보낼 때, DB에 저장된 알림의 PK(notification_id)가 필요합니다.
- 따라서 DB 저장과 Kafka 전송을 병렬로 처리하지 않고, DB 저장(Side Effect) 후 리턴된 ID를 받아 Kafka로 전송하는 순차적 흐름으로 구현했습니다.
3. 쿨타임 적용
- 동일 종목에 대해 알림이 폭주하는 것을 막기 위해 check_recent_alert 유틸 함수를 통해 중복 발송을 방지하고 있습니다.

## 🔗 문서
- [Flink 알림 시스템: 이상(Broadcast)과 현실의 간극 좁히기](https://www.notion.so/Flink-Broadcast-2cc0c3d3c9ea80cca4efdd88189fbc67?source=copy_link)

## 🧪 테스트 방법
1. `docker-compose up -d --build` 실행 (compose파일 등 수정사항이 많아 꼭 이미지 재빌드 해야합니다!)
2. `docker exec -it gaemi_backend python manage.py migrate` 실행
3. `docker exec -it gaemi_db bash`-> `psql -U gaemi -d gaemi_ai`
4. 임시 user 및 알람 규칙 추가
- `INSERT INTO users (
    id, 
    username, 
    password, 
    first_name, 
    last_name, 
    email, 
    nickname, 
    is_superuser, 
    is_staff, 
    is_active, 
    date_joined, 
    created_at
)
VALUES (
    1, 
    'test_user', 
    'dummy_pass', 
    'Gildong',   -- first_name (필수)
    'Hong',      -- last_name (혹시 몰라 채움)
    'test@test.com', -- email (혹시 몰라 채움)
    'GaemiBot',  -- nickname (스키마에 보여서 채움)
    false, 
    false, 
    true, 
    NOW(), 
    NOW()
);`

- `INSERT INTO user_notification_rules (
    user_id, 
    stock_id, 
    metric_type, 
    operator, 
    target_value, 
    is_active
)
VALUES (
    1, 
    '005930', 
    'price', 
    '>=', 
    '100', 
    true
);`

5. (주식장이 열려있다면 생략가능) 가짜 데이터 주입 `docker exec -it gaemi_flink_jobmanager bash` -> `python /opt/flink/usrlib/jobs/mock_producer.py` (종료시 가짜 데이터 주입도 멈추니 추가 로그 확인을 위해 터미널을 사용해야한다면 별도의 창을 따로 열고 실행해주세요)
6. kafka UI 확인 (localhost:8080)
<img width="2229" height="559" alt="스크린샷 2025-12-17 오전 2 16 58" src="https://github.com/user-attachments/assets/ccf09747-db2a-4a10-b27b-38fd93f7acb9" />

alert topic 적재 확인
<img width="2237" height="692" alt="스크린샷 2025-12-17 오전 2 57 50" src="https://github.com/user-attachments/assets/5bac7ad6-3d7b-4407-90c6-7c30034899ad" />


7. flink UI 확인 (localhost:8081)
<img width="2227" height="923" alt="스크린샷 2025-12-17 오전 2 56 20" src="https://github.com/user-attachments/assets/3d1c83c8-333b-4ccb-a1f7-b919fe47bc06" />

- 의존성을 다수 주입하여 job 등록까지 시간이 꽤 걸릴 수 있습니다. 
- 터미널에서 확인시 `docker-compose logs -f flink-job-submitter` (일회성 컨테이너이므로 잡이 모두 처리되었다면 없는 컨테이너라고 뜰 수 있습니다. 그런 경우 UI로 위 그림처럼 정상 처리되었는지 확인부탁드립니다.)

8. Kibana UI 확인 (localhost:5601)
<img width="2232" height="464" alt="스크린샷 2025-12-17 오전 2 17 18" src="https://github.com/user-attachments/assets/68b53b09-74da-4a26-96bf-975f340a199c" />

<img width="2230" height="891" alt="스크린샷 2025-12-17 오전 2 17 35" src="https://github.com/user-attachments/assets/289f3652-25b4-463e-8c32-3fd0e6a1b523" />

<img width="4460" height="2054" alt="image" src="https://github.com/user-attachments/assets/7b30810b-9ef2-4078-9770-4ff630dd4770" />


- 이전 PR 참고하여 접속 후 확인부탁드립니다. 만약 필수 선택 항목을 선택하지 않았다고 하면 timestamp 지정  후 추가하시면 됩니다.

9. PostgreSQL 데이터 적재 확인
- `docker exec -it gaemi_db bash`-> `psql -U gaemi -d gaemi_ai`
- `SELECT * FROM triggered_notifications;`or `SELECT * FROM triggered_notifications LIMIT 10;`

<img width="945" height="255" alt="스크린샷 2025-12-17 오전 2 57 38" src="https://github.com/user-attachments/assets/21a1b201-228b-46d6-be33-27141aee68aa" />
