### PR TITLE
[I-36] Elasticsearch 기반 주식 차트(OHLC) 데이터 조회 API 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - [중복방지를 위한 2단계 방어선 구축! In-Memory Filtering + Kafka Log Compaction](https://www.notion.so/2-In-Memory-Filtering-Kafka-Log-Compaction-2c00c3d3c9ea802eb722e7f050803e6c?source=copy_link)
 - [왜 기사 전체 내용을 Embedding 변환하지 않았나요?](https://www.notion.so/Embedding-2c60c3d3c9ea8049b09af74c3625ebe4?source=copy_link)
 - [Flink 알림 시스템: 이상(Broadcast)과 현실의 간극 좁히기](https://www.notion.so/Flink-Broadcast-2cc0c3d3c9ea80cca4efdd88189fbc67?source=copy_link)
+- [주식 캔들 차트: 시간 축의 불연속성을 선택한 기술적 배경](https://www.notion.so/2cd0c3d3c9ea807bbe58de48840eba98?source=copy_link)
 
 ## 📌 Git 협업 전략
 -

--- a/gaemi-project/backend-pjt/gaemi_backend/settings.py
+++ b/gaemi-project/backend-pjt/gaemi_backend/settings.py
@@ -55,7 +55,9 @@ INSTALLED_APPS = [
     'stocks',
     'watchlist',
     'notifications',
-    'chatbot'
+    'chatbot',
+
+    'drf_yasg' # API 명세 페이지
 ]
 
 

--- a/gaemi-project/backend-pjt/gaemi_backend/urls.py
+++ b/gaemi-project/backend-pjt/gaemi_backend/urls.py
@@ -16,6 +16,25 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework import permissions
+
+# 🌟 Swagger 관련 임포트
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+# 🌟 Swagger 정보 설정
+schema_view = get_schema_view(
+   openapi.Info(
+      title="gAemI-AI API",
+      default_version='v1',
+      description="gAemi-AI 프로젝트 API 명세서입니다.",
+      terms_of_service="https://www.google.com/policies/terms/",
+      contact=openapi.Contact(email="contact@gaemi.ai"),
+      license=openapi.License(name="BSD License"),
+   ),
+   public=True,
+   permission_classes=[permissions.AllowAny],
+)
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -28,10 +47,16 @@ urlpatterns = [
 
     # 3. 관심 종목 API
     path('api/v1/watchlist/', include('watchlist.urls')),
-
+    
     # 4. 알림 API 연결
     path('api/v1/notifications/', include('notifications.urls')),
 
     # 5. chatbot 연결
-    path('api/chatbot/', include('chatbot.urls')), #  /api/chatbot/ask/ 로 요청
+    path('api/v1/chatbot/', include('chatbot.urls')), #  /api/chatbot/ask/ 로 요청
+
+    # ------------- Swagger URL 연결 ------------- #
+    path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    # ------------------------------------------ #
 ]

--- a/gaemi-project/backend-pjt/requirements.txt
+++ b/gaemi-project/backend-pjt/requirements.txt
@@ -12,3 +12,5 @@ djangorestframework
 elasticsearch-dsl    # ES 통신용 (공식 라이브러리)
 openai               # GPT 호출용
 elasticsearch
+
+drf-yasg

--- a/gaemi-project/backend-pjt/stocks/urls.py
+++ b/gaemi-project/backend-pjt/stocks/urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
 from .views import StockListView
+from .views import StockListView, StockChartView # StockChartView 임포트
 
 urlpatterns = [
     # GET / api/v1/stocks/ 주소로 요청오면 -> StockListView가 처리
     path('', StockListView.as_view(), name='stock-list'),
+
+    # 차트 데이터 API: (예) /api/v1/stocks/005930/chart/
+    path('<str:stock_code>/chart/', StockChartView.as_view(), name='stock_chart'),
 ]

--- a/gaemi-project/backend-pjt/stocks/views.py
+++ b/gaemi-project/backend-pjt/stocks/views.py
@@ -2,6 +2,12 @@ from rest_framework import generics # ListAPIView: 단순 조회 업무를 위�
 from .models import StockMaster
 from .serializers import StockMasterSerializer
 from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from django.conf import settings
+from elasticsearch import Elasticsearch
+from datetime import datetime, timedelta
 
 # 주식 목록 조회 전용 뷰 (GET)
 class StockListView(generics.ListAPIView):
@@ -13,3 +19,125 @@ class StockListView(generics.ListAPIView):
 
     # 3. 누구에게 보여줄건지 -> 로그인한 사람에게만
     permission_classes = [AllowAny] # 모두에게 보여주려면 AllowAny으로 바꾸면 됨!
+
+# 주식 차트 데이터 조회 API (OHLC Aggregation)
+#   - ES의 주식 틱 데이터를 조회하여 지정된 시간 간격으로 집계한 캔들 데이터를 반환
+#   - URL: GET /api/v1/stocks/{stock_code}/chart/?range=1d&interval=1m
+class StockChartView(APIView):
+    permission_classes = [AllowAny]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.es = Elasticsearch(
+            hosts=[{'host': 'elasticsearch', 'port': 9200, 'scheme': 'http'}]
+        )
+
+    def get(self, request, stock_code):
+        # 1. 파라미터 파싱
+        search_range = request.query_params.get('range', '1d')   
+        interval = request.query_params.get('interval', '1m')    
+
+        # 2. 조회 기간 계산 (ISO String 형식으로 변환)
+        now = datetime.now()
+        start_time = now - timedelta(days=1) 
+        
+        if search_range == '1d':
+            start_time = now - timedelta(days=1)
+        elif search_range == '1w':
+            start_time = now - timedelta(weeks=1)
+        elif search_range == '1M':
+            start_time = now - timedelta(days=30)
+            
+        #  데이터가 "2025-12-16T..." 문자열이므로, 쿼리도 문자열로
+        gte_timestamp = start_time.isoformat() 
+
+        # 3. ES 집계 쿼리 작성
+        query_body = {
+            "size": 0,  # 개별 문서는 가져오지 않음 (집계만)
+            "query": {
+                "bool": {
+                    "filter": [
+                        {"term": {"stock_code": stock_code}}, 
+                        # range 쿼리에 ISO 문자열 사용
+                        {"range": {"timestamp": {"gte": gte_timestamp}}} 
+                    ]
+                }
+            },
+            "aggs": {
+                "candles": {
+                    # 캔들 봉 만들기
+                    "date_histogram": {
+                        "field": "timestamp", # timestamp 기준으로 일정 시간 단위로 묶음
+                        "fixed_interval": interval,
+                        "time_zone": "+09:00", # 한국 주식 -> KST 기준
+                        "min_doc_count": 1 # 이 구간에 문서가 최소 1개 이상 있는 버킷만 만듦 / 없다면? 데이터가 없어도 버킷 생성
+                        # 연속된 시간 축을 만들기 위해서는 이게 0 이여야함 
+                        # but 우리는 지금 체결 정보 즉 이벤트 기반이므로 거래가 발생했을때만 의미있는 데이터가 생김
+                        # 캔들 차트는 시간이 아니라 가격 변화를 보여줌으로 가짜 캔들을 만들면 오히려 정보가 왜곡 될 수 있음
+                    },
+                    "aggs": {
+                        # 고가 / 저가
+                        "high": {"max": {"field": "current_price"}}, # 해당 봉에서 가장 비싼 값
+                        "low": {"min": {"field": "current_price"}}, # 해당 봉에서 가장 싼 값
+                        
+                        # 데이터에 tick_volume이 있으면 합산
+                        "volume": {"sum": {"field": "tick_volume"}},
+
+                        # 시가 
+                        "open_record": {
+                            "top_hits": {
+                                "sort": [{"timestamp": "asc"}], # 봉 시작 시가나 가장 처음 체결된 가격
+                                "_source": ["current_price"], 
+                                "size": 1
+                            }
+                        },
+                        # 종가 
+                        "close_record": {
+                            "top_hits": {
+                                "sort": [{"timestamp": "desc"}], # 봉 끝 시간 가장 마지막 체결 가격
+                                "_source": ["current_price"], 
+                                "size": 1
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        try:
+            response = self.es.search(index="raw-stocks", body=query_body)
+            buckets = response['aggregations']['candles']['buckets'] # 하나의 bucket -> 하나의 봉
+
+            chart_data = []
+            for bucket in buckets:
+                # 데이터 안전하게 꺼내기 (ES 집계가 비어있을 수 있음)
+                open_hits = bucket['open_record']['hits']['hits']
+                close_hits = bucket['close_record']['hits']['hits']
+                
+                if open_hits and close_hits:
+                    open_source = open_hits[0]['_source']
+                    close_source = close_hits[0]['_source']
+                    
+                    # 1순위: current_price, 2순위: price, 없으면: 0
+                    open_price = open_source.get('current_price', open_source.get('price', 0))
+                    close_price = close_source.get('current_price', close_source.get('price', 0))
+                    high_price = bucket['high']['value']
+                    low_price = bucket['low']['value']
+                    volume = bucket['volume']['value']
+                    
+                    # High/Low가 None일 경우 방어 (혹시 모를 상황 대비) -> 집계가 깨졌더라도 차트는 최소한 그려질 수 있도록 방어
+                    if high_price is None: high_price = max(open_price, close_price)
+                    if low_price is None: low_price = min(open_price, close_price)
+
+                    # 응답 구조: { x: 시간, y: [시,고,저,종], v: 거래량 }
+                    chart_data.append({
+                        "x": bucket['key'],  # 시간
+                        "y": [open_price, high_price, low_price, close_price], # 가격 [O,H,L,C]
+                        "v": int(volume)  # 소수점 제거
+                    })
+
+            return Response(chart_data, status=status.HTTP_200_OK) # 차트에 바인딩
+
+        except Exception as e:
+            print(f"Chart Error: {e}")
+            return Response([], status=status.HTTP_200_OK)


### PR DESCRIPTION
## 📌 개요

프론트엔드 대시보드의 핵심 기능인 '주식 캔들 차트' 시각화를 위해, Elasticsearch에 적재된 실시간 틱 데이터(`raw-stocks`)를 조회하고 서버 사이드에서 OHLCV(시가/고가/저가/종가/거래량)로 집계(Aggregation)하여 반환하는 REST API를 구현했습니다.
추가로 프론트엔드와의 원활한 협업을 위해 **Swagger(API 문서화)** 환경을 구축했습니다.

## ✨ 주요 변경 사항
- [x] StockChartView 구현:
* `GET /api/v1/stocks/{stock_code}/chart/` 엔드포인트 생성
* 쿼리 파라미터(`range`, `interval`)를 통해 기간 및 봉 차트 간격 조절 지원


- [x] Elasticsearch Aggregation 로직 고도화:
* `date_histogram`: 1분(`1m`) 등 동적 간격 버킷 생성
* `top_hits` & `min/max`: 각 버킷별 시가(Open), 종가(Close), 최고가(High), 최저가(Low) 산출
* `sum`: 각 버킷별 누적 거래량(Volume) 산출 (필드명: `tick_volume`)


- [x] 데이터 안정성(Robustness) 확보:
* `current_price` 필드를 우선하되, 테스트 데이터(`price`)가 혼재된 경우에도 에러 없이 처리되도록 `get().get()` 체이닝 방어 로직 적용

- [x] API 문서화 (Swagger):
* `drf-yasg` 라이브러리 도입 및 `/swagger/`, `/redoc/` 경로 설정
* API URL 네임스페이스를 `/api/v1/`으로 표준화

## 🔍 관련 이슈

[I-36](https://github.com/gAemI-AI/gAemI-AI/issues/36)

## 🙏 To Reviewers

1. **서버 사이드 집계 (Server-side Aggregation)**
* 수많은 틱 데이터를 클라이언트로 그대로 전송하는 대신, ES의 Aggregation 기능을 활용해 완성된 캔들 데이터만 전송하여 네트워크 및 브라우저 부하를 최소화했습니다.


2. **응답 포맷 (Chart Library Friendly)**
* 차트 라이브러리(ApexCharts 등)에서 바로 사용할 수 있도록 `{ x: timestamp, y: [O, H, L, C], v: volume }` 구조로 데이터를 포맷팅했습니다.


3. **URL 규칙 변경**
* Swagger 도입과 함께 API 버전 관리를 위해 기존 `/api/chatbot/` 등의 경로를 `/api/v1/chatbot/`, `/api/v1/stocks/` 형태로 통일했습니다. 프론트엔드 연동 시 참고 부탁드립니다.



## 🧪 테스트 방법

### 1. 컨테이너 재빌드 및 실행

새로운 패키지(`drf-yasg`) 설치 및 URL 변경이 있었으므로 재빌드가 필요합니다.
(필수 컨테이너: backend, db, elasticsearch)

```bash
# 아무 컨테이너도 띄워져있지 않은 경우
docker-compose up -d --build backend elasticsearch db

# 컨테이너가 모두 띄워져 있는 경우에는 backend만 재빌드
docker-compose up -d --build backend

```

### 2. (선택) 테스트 데이터 주입
**신중히 수행해주세요. 개인적으로는 테스트 데이터 주입보다 실제 실행 후 es에 쌓인 데이터를 활용하는 것을 추천하나 여건이 안된다면 테스트 데이터로 수행해주시면 됩니다!**

ES에 데이터가 없다면 아래 명령어로 현재 시간 기준의 데이터를 주입합니다. (터미널 복사 붙여넣기)

```bash
# 타임스탬프 변수 생성
NOW_SEC=$(date +%s)
TS_NOW=$((NOW_SEC * 1000))

# 데이터 주입 (current_price, tick_volume 포함)
curl -X POST "http://localhost:9200/raw-stocks/_doc/" \
-H 'Content-Type: application/json' \
-d "{
  \"stock_code\": \"005930\",
  \"current_price\": 82000,
  \"tick_volume\": 100,
  \"timestamp\": $TS_NOW
}"

```

### 3. API 동작 테스트 (cURL)

삼성전자(005930)의 최근 1주일 데이터를 1분 봉으로 조회합니다.

```bash
curl "http://localhost:8000/api/v1/stocks/005930/chart/?range=1w&interval=1m"

```

### 4. 결과 검증

응답이 아래와 같이 **가격 배열(y)**과 **거래량(v)**이 포함된 JSON 배열로 오는지 확인합니다.

**✅ 성공 응답 예시:**

```json
[
  {
    "x": 1765907700000,
    "y": [82000, 82000, 82000, 82000], 
    "v": 100
  }
]

```

### 5. Swagger 확인

브라우저에서 `http://localhost:8000/swagger/` 로 접속하여 API 명세서가 정상적으로 뜨는지 확인합니다.
프론트엔드 작업시 참고할 수 있도록 API 명세서 페이지를 구성했습니다. 프론트 구성시 꼭 참고해주세요.

<img width="2225" height="947" alt="image" src="https://github.com/user-attachments/assets/721dd87b-683f-41c2-83d2-639154578514" />
