### PR TITLE
 [I-39] 관심 종목(Watchlist) API 및 종목 검색 기능 구현

### DIFF
--- a/gaemi-project/backend-pjt/stocks/urls.py
+++ b/gaemi-project/backend-pjt/stocks/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from .views import StockListView
 from .views import StockListView, StockChartView # StockChartView 임포트
+from .views import StockListView, StockChartView, MarketIndexView 
 
 urlpatterns = [
     # GET / api/v1/stocks/ 주소로 요청오면 -> StockListView가 처리
@@ -8,4 +9,7 @@ urlpatterns = [
 
     # 차트 데이터 API: (예) /api/v1/stocks/005930/chart/
     path('<str:stock_code>/chart/', StockChartView.as_view(), name='stock_chart'),
+
+    # 시장 지수 API
+    path('market-index/', MarketIndexView.as_view(), name='market-index'),
 ]

--- a/gaemi-project/backend-pjt/stocks/views.py
+++ b/gaemi-project/backend-pjt/stocks/views.py
@@ -9,6 +9,10 @@ from django.conf import settings
 from elasticsearch import Elasticsearch
 from datetime import datetime, timedelta
 from rest_framework import filters
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from elasticsearch import Elasticsearch
 
 # 주식 목록 조회 전용 뷰 (GET)
 class StockListView(generics.ListAPIView):
@@ -145,4 +149,64 @@ class StockChartView(APIView):
 
         except Exception as e:
             print(f"Chart Error: {e}")
+            return Response([], status=status.HTTP_200_OK)
+        
+# 여러 지수의 최신 상태 조회
+class MarketIndexView(APIView):
+    permission_classes = [AllowAny]
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.es = Elasticsearch(
+            hosts=[{'host': 'elasticsearch', 'port': 9200, 'scheme': 'http'}]
+        )
+
+    def get(self, request):
+        # Elasticsearch 쿼리: 각 지수(symbol)별로 최신 데이터 1개씩 가져오기
+        query_body = {
+            "size": 0,  # 전체 목록은 필요 없고 집계 결과만 필요함
+            "aggs": {
+                "indices": {
+                    "terms": { 
+                        "field": "symbol",  # KOSPI, KOSDAQ 등으로 그룹핑
+                        "size": 10 
+                    },
+                    "aggs": {
+                        "latest_data": {
+                            "top_hits": {
+                                "sort": [{"timestamp": "desc"}], # 최신순 정렬
+                                "size": 1,
+                                "_source": ["symbol", "current_price", "diff", "rate"] # 필요한 필드만
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        try:
+            # 데이터가 없다면 빈 리스트 반환
+            if not self.es.indices.exists(index="index-ticks"):
+                return Response([], status=status.HTTP_200_OK)
+
+            response = self.es.search(index="index-ticks", body=query_body)
+            buckets = response['aggregations']['indices']['buckets']
+
+            result = []
+            for bucket in buckets:
+                hits = bucket['latest_data']['hits']['hits']
+                if hits:
+                    source = hits[0]['_source']
+                    result.append({
+                        "name": source.get('symbol'),
+                        "price": source.get('current_price'),
+                        "diff": source.get('diff'),
+                        "rate": source.get('rate')
+                    })
+
+            return Response(result, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            print(f"Market Index Error: {e}")
+            # 에러 발생 시 빈 배열 반환하여 프론트 터짐 방지
             return Response([], status=status.HTTP_200_OK)

--- a/gaemi-project/backend-pjt/stocks/views.py
+++ b/gaemi-project/backend-pjt/stocks/views.py
@@ -8,6 +8,7 @@ from rest_framework import status
 from django.conf import settings
 from elasticsearch import Elasticsearch
 from datetime import datetime, timedelta
+from rest_framework import filters
 
 # 주식 목록 조회 전용 뷰 (GET)
 class StockListView(generics.ListAPIView):
@@ -19,6 +20,10 @@ class StockListView(generics.ListAPIView):
 
     # 3. 누구에게 보여줄건지 -> 로그인한 사람에게만
     permission_classes = [AllowAny] # 모두에게 보여주려면 AllowAny으로 바꾸면 됨!
+
+    # 4. 검색 기능 활성화
+    filter_backends = [filters.SearchFilter]
+    search_fields = ['stock_name', 'stock_id', 'market_type']
 
 # 주식 차트 데이터 조회 API (OHLC Aggregation)
 #   - ES의 주식 틱 데이터를 조회하여 지정된 시간 간격으로 집계한 캔들 데이터를 반환

--- a/gaemi-project/backend-pjt/watchlist/models.py
+++ b/gaemi-project/backend-pjt/watchlist/models.py
@@ -5,11 +5,9 @@ from stocks.models import StockMaster
 class Watchlist(models.Model):
     watchlist_id = models.BigAutoField(primary_key=True) 
     # user와 1:N
-    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='watchlist') # related_name: 역참조 이름을 지정하는 옵션, 즉 ForeignKey가 연결된 반대쪽 모델에서 이 관계를 어떻게 부를지
-
+    user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='watchlist')
     # StockMaster와 1:N관계
     stock = models.ForeignKey(StockMaster, on_delete=models.CASCADE, related_name='watched_by')
-
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:

--- a/gaemi-project/backend-pjt/watchlist/views.py
+++ b/gaemi-project/backend-pjt/watchlist/views.py
@@ -52,7 +52,7 @@ class WatchlistListCreateView(generics.ListCreateAPIView):
                 },
                 "aggs": {
                     "by_stock": {
-                        "terms": {"field": "stock_code", "size": 100},  # stock_code 기준으로 bucket 생성 (최대 100 종목까지만 가능하도록 설정)
+                        "terms": {"field": "stock_code.keyword", "size": 100},  # stock_code 기준으로 bucket 생성 (최대 100 종목까지만 가능하도록 설정)
                         "aggs": {
                             "latest_price": {
                                 "top_hits": { # 각 bucket 안에서 실제 문서를 다시 가져오는 집계(가장 최신 것만 가져오기 위해)

--- a/gaemi-project/backend-pjt/watchlist/views.py
+++ b/gaemi-project/backend-pjt/watchlist/views.py
@@ -1,21 +1,100 @@
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 from .models import Watchlist
 from .serializers import WatchlistSerializer
 from django.shortcuts import get_object_or_404
+from elasticsearch import Elasticsearch
 
 # 1. 목록 조회(GET) 및 추가(POST)
 class WatchlistListCreateView(generics.ListCreateAPIView):
     serializer_class = WatchlistSerializer
     permission_classes = [IsAuthenticated] # 로그인 필수
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        # ES 연결 설정
+        self.es = Elasticsearch(
+            hosts=[{'host': 'elasticsearch', 'port': 9200, 'scheme': 'http'}]
+        )
+
     # 로그인한 유저의 데이터만 가져옴 (User Isolation)
     def get_queryset(self):
-        return Watchlist.objects.filter(user=self.request.user)
+        return Watchlist.objects.filter(user=self.request.user).order_by('-created_at')
     
     # user 필드는 로그인한 사람으로 자동 채움
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
+
+    # 목록 조회 시 '현재가' 주입하기
+    def list(self, request, *args, **kwargs):
+        # 1. DB에서 내 관심 종목 리스트 가져오기
+        response = super().list(request, *args, **kwargs)
+        watchlist_data = response.data 
+
+        if not watchlist_data:
+            return response
+
+        # 2. 종목 코드 리스트 추출
+        stock_codes = [item['stock'] for item in watchlist_data]
+
+        # 3. Elasticsearch에서 최신 가격 조회 (Terms Aggregation)
+        try:
+            es_query = {
+                "size": 0, # 문서 자체는 필요 없음
+                "query": {
+                    "bool": {
+                        "filter": [
+                            {"terms": {"stock_code": stock_codes}} # 내 종목들만 필터링
+                        ]
+                    }
+                },
+                "aggs": {
+                    "by_stock": {
+                        "terms": {"field": "stock_code", "size": 100},  # stock_code 기준으로 bucket 생성 (최대 100 종목까지만 가능하도록 설정)
+                        "aggs": {
+                            "latest_price": {
+                                "top_hits": { # 각 bucket 안에서 실제 문서를 다시 가져오는 집계(가장 최신 것만 가져오기 위해)
+                                    "sort": [{"timestamp": "desc"}], # 최신순
+                                    "_source": ["current_price", "diff", "rate"],  # 필요한 필드만 선택
+                                    "size": 1 # 현재가 최신 1건만 필요
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            es_res = self.es.search(index="raw-stocks", body=es_query)
+            buckets = es_res['aggregations']['by_stock']['buckets']
+
+            # 4. 가격 데이터 매핑 (Dictionary 변환)
+            price_map = {}
+            for bucket in buckets:
+                code = bucket['key']
+                hits = bucket['latest_price']['hits']['hits']
+                if hits:
+                    source = hits[0]['_source']
+                    price_map[code] = {
+                        "current_price": source.get('current_price', 0),
+                        "diff": source.get('diff', 0),
+                        "rate": source.get('rate', 0.0)
+                    }
+
+            # 5. 기존 응답 데이터에 가격 정보 합치기
+            for item in watchlist_data:
+                code = item['stock']
+                # ES에서 가져온 가격 정보가 있으면 병합, 없으면 0 처리
+                price_info = price_map.get(code, {"current_price": 0, "diff": 0, "rate": 0.0})
+                item.update(price_info)
+
+            return Response(watchlist_data)
+
+        except Exception as e:
+            print(f"Watchlist Price Error: {e}")
+            # 에러가 나더라도 목록은 보여줘야 함 (가격은 0으로)
+            return response
 
 # 2. 삭제(Delete) - stock_id 기준 (관심종목에서 주식 삭제 API)
 class WatchlistDestroyView(generics.DestroyAPIView):


### PR DESCRIPTION
## 📌 개요

사용자 개인화 경험의 핵심인 **'관심 종목(Watchlist)' 관리 기능**과, 원하는 주식을 빠르게 찾을 수 있는 **'종목 검색(Search)' API**를 구현했습니다.
특히 관심 종목 목록 조회 시, **RDBMS(관계 정보)**와 **Elasticsearch(실시간 시세)**의 데이터를 애플리케이션 레벨에서 병합(Hybrid Merge)하여 최신성을 보장하도록 설계했습니다.

## ✨ 주요 변경 사항

* **[Feat] 관심 종목(Watchlist) CRUD API 구현**
* `GET /api/v1/watchlist/`: 내 관심 종목 + **현재가/등락률(ES)** 조회
* `POST /api/v1/watchlist/`: 종목 추가 (중복 등록 시 400 에러 처리 적용)
* `DELETE /api/v1/watchlist/{stock_id}/`: 종목 삭제


* **[Feat] 종목 검색(Search) API 구현**
* `GET /api/v1/stocks/?search={keyword}`: 종목명, 종목코드, 시장구분 검색 지원


* **[Fix] Elasticsearch 집계 오류 수정**
* `stock_code` 텍스트 필드 집계 시 발생하는 `Fielddata` 에러 해결을 위해 `.keyword` 필드 사용으로 변경


* **[Refactor] 예외 처리 강화**
* 중복 등록 시 `IntegrityError`를 포착하여 `ValidationError`("이미 등록된 종목입니다")로 반환하도록 개선



## 🔍 관련 이슈

* [I-39](https://github.com/gAemI-AI/gAemI-AI/issues/39)

## 🙏 To Reviewers

* **`watchlist/views.py`의 `list` 메서드**를 중점적으로 봐주세요. DB에서 가져온 종목 리스트를 기반으로 ES에서 `Terms Aggregation`을 수행하여 가격 정보를 매핑하는 로직이 들어있습니다.
* 현재 Elasticsearch에 실시간 데이터 파이프라인이 연결되지 않아, 테스트 시에는 수동으로 데이터를 넣거나 `0`으로 표시될 수 있습니다. (테스트 방법 참고)

## 🔗 문서

* [Swagger UI 확인](https://www.google.com/search?q=http://localhost:8000/swagger/&authuser=1)

```markdown
## 🧪 테스트 방법

### 0. 사전 준비 (서버 재시작 & 마이그레이션)
```bash
docker-compose restart backend
docker exec -it gaemi_backend python manage.py migrate

```

### 1. 검색 API 테스트

로그인 없이 검색이 잘 되는지 확인합니다.

```bash
curl "http://localhost:8000/api/v1/stocks/?search=삼성"

```

### 2. 관심 종목 하이브리드 로직 테스트 
- docker container가 모두 떠 있는 경우(es에 데이터가 이미 존재하는 경우)에는 생략 후 바로 목록 조회하시면 됩니다.

**Step A: Elasticsearch에 가짜 가격 데이터 주입 (삼성전자: 005930)**

```bash
curl -X POST "http://localhost:9200/raw-stocks/_doc/" \
-H 'Content-Type: application/json' \
-d '{ "stock_code": "005930", "current_price": 99999, "diff": 5000, "rate": 5.5, "timestamp": 1735689600000 }'

```

**Step B: 관심 종목 등록 (POST)**
(Postman 사용 권장, Header에 `Authorization: Bearer <TOKEN>` 필수)

* **URL:** `http://localhost:8000/api/v1/watchlist/`
* **Body:** `{ "stock": "005930" }`

**Step C: 목록 조회 (GET)**
응답 결과에 `current_price: 99999`가 포함되어 있으면 성공입니다.

```bash
curl -H "Authorization: Bearer <YOUR_TOKEN>" http://localhost:8000/api/v1/watchlist/

```

## 📸 스크린샷/동작 확인
<img width="899" height="711" alt="image" src="https://github.com/user-attachments/assets/bc687f67-858f-4a02-b3d8-837ee0d6b79b" />

## ✅ 체크리스트

* [x] 관심 종목 등록/삭제가 DB에 정상 반영되는가?
* [x] 목록 조회 시 ES의 가격 정보가 병합되어 나오는가?
* [x] 중복 등록 시 500 에러 대신 400 에러 메시지가 반환되는가?
* [x] 종목 검색이 정상적으로 동작하는가?

## ⚠️ 추가 고려 사항

* 현재는 ES에 데이터가 없으면 가격이 0으로 표시됩니다. 추후 Kafka Consumer 연동 시 실제 데이터가 반영됩니다.
* 검색 기능은 현재 DB `icontains` 기반이며, 추후 ES 형태소 분석기 도입 예정입니다.
* 또한 index-ticks 활용  API도 추후 도입 예정입니다. 
