### PR TITLE
[I-41] 시장 지수(Index) 실시간 처리 파이프라인 구축 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - [왜 기사 전체 내용을 Embedding 변환하지 않았나요?](https://www.notion.so/Embedding-2c60c3d3c9ea8049b09af74c3625ebe4?source=copy_link)
 - [Flink 알림 시스템: 이상(Broadcast)과 현실의 간극 좁히기](https://www.notion.so/Flink-Broadcast-2cc0c3d3c9ea80cca4efdd88189fbc67?source=copy_link)
 - [주식 캔들 차트: 시간 축의 불연속성을 선택한 기술적 배경](https://www.notion.so/2cd0c3d3c9ea807bbe58de48840eba98?source=copy_link)
+- [Kafka → Elasticsearch Index Consumer 설계 및 구현 배경](https://www.notion.so/Kafka-Elasticsearch-Index-Consumer-2cf0c3d3c9ea8068a0ede8a2d90a6a6c?source=copy_link)
 
 ## 📌 Git 협업 전략
 -

--- a/gaemi-project/backend-pjt/stocks/views.py
+++ b/gaemi-project/backend-pjt/stocks/views.py
@@ -151,32 +151,43 @@ class StockChartView(APIView):
             print(f"Chart Error: {e}")
             return Response([], status=status.HTTP_200_OK)
         
-# 여러 지수의 최신 상태 조회
+# 메인 대시보드용 시장 지수(KOSPI, KOSDAQ 등) 조회 API
 class MarketIndexView(APIView):
     permission_classes = [AllowAny]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        
+        # Docker 내부 통신용 ES 주소
         self.es = Elasticsearch(
             hosts=[{'host': 'elasticsearch', 'port': 9200, 'scheme': 'http'}]
         )
+        
+        # 데이터 코드 -> 화면 표시 이름 매핑
+        self.INDEX_MAP = {
+            "0001": "KOSPI",
+            "1001": "KOSDAQ",
+            "2001": "KOSPI200"
+        }
 
     def get(self, request):
-        # Elasticsearch 쿼리: 각 지수(symbol)별로 최신 데이터 1개씩 가져오기
+        # 1. ES Aggregation 쿼리
+        # - index_code별로 그룹핑하여 가장 최신(timestamp desc) 데이터 1개만 가져옴
         query_body = {
-            "size": 0,  # 전체 목록은 필요 없고 집계 결과만 필요함
+            "size": 0,
             "aggs": {
                 "indices": {
+                    # Consumer에서 mapping한 대로 .keyword 필드 사용 필수
                     "terms": { 
-                        "field": "symbol",  # KOSPI, KOSDAQ 등으로 그룹핑
-                        "size": 10 
+                        "field": "index_code.keyword", 
+                        "size": 10 # 현재는 3개이지만 확장 대비로 10개
                     },
                     "aggs": {
                         "latest_data": {
                             "top_hits": {
-                                "sort": [{"timestamp": "desc"}], # 최신순 정렬
+                                "sort": [{"timestamp": "desc"}],
                                 "size": 1,
-                                "_source": ["symbol", "current_price", "diff", "rate"] # 필요한 필드만
+                                "_source": ["index_code", "current_value", "change_value", "change_rate"]
                             }
                         }
                     }
@@ -185,7 +196,7 @@ class MarketIndexView(APIView):
         }
 
         try:
-            # 데이터가 없다면 빈 리스트 반환
+            # 인덱스가 아직 생성되지 않았을 경우 (Consumer 실행 전) 방어 코드
             if not self.es.indices.exists(index="index-ticks"):
                 return Response([], status=status.HTTP_200_OK)
 
@@ -197,16 +208,25 @@ class MarketIndexView(APIView):
                 hits = bucket['latest_data']['hits']['hits']
                 if hits:
                     source = hits[0]['_source']
+                    raw_code = source.get('index_code')
+                    
+                    # 2. 데이터 변환 (Backend -> Frontend 규격 맞춤)
+                    display_name = self.INDEX_MAP.get(raw_code, raw_code) # 매핑 없으면 코드 그대로 출력
+                    
                     result.append({
-                        "name": source.get('symbol'),
-                        "price": source.get('current_price'),
-                        "diff": source.get('diff'),
-                        "rate": source.get('rate')
+                        "name": display_name,                 # 예: "KOSPI"
+                        "price": source.get('current_value'), # 예: 2500.50
+                        "diff": source.get('change_value'),   # 예: -15.2
+                        "rate": source.get('change_rate')     # 예: -0.6
                     })
+
+            # 3. 화면 표시 순서 정렬 (KOSPI -> KOSDAQ -> 나머지)
+            order_priority = {"KOSPI": 1, "KOSDAQ": 2, "KOSPI200": 3}
+            result.sort(key=lambda x: order_priority.get(x['name'], 99))
 
             return Response(result, status=status.HTTP_200_OK)
 
         except Exception as e:
-            print(f"Market Index Error: {e}")
-            # 에러 발생 시 빈 배열 반환하여 프론트 터짐 방지
+            print(f"🚨 Market Index Error: {e}")
+            # 에러 발생 시 500 대신 빈 배열 반환 (프론트엔드 보호)
             return Response([], status=status.HTTP_200_OK)

--- a/gaemi-project/data-pjt/consumer-index/Dockerfile
+++ b/gaemi-project/data-pjt/consumer-index/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.10-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py"]

--- a/gaemi-project/data-pjt/consumer-index/main.py
+++ b/gaemi-project/data-pjt/consumer-index/main.py
@@ -1,0 +1,107 @@
+# gaemi-project > data-pjt > consumer-index > main.py
+# Kafka 토픽(index-ticks)에서 지수 데이터를 실시간 소비 -> Elasticsearch에 index_code 기준으로 최신 값만 Upsert 저장
+# 즉, 현재 상태 테이블 형태 저장
+
+import json
+import logging
+import os
+import sys
+import time
+from kafka import KafkaConsumer
+from elasticsearch import Elasticsearch, helpers
+
+# 로깅 설정
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+# 환경변수 로드
+KAFKA_BROKER = os.environ.get("KAFKA_BROKER", "kafka:9092")
+TOPIC_NAME = os.environ.get("TOPIC_NAME", "index-ticks")
+ES_HOST = os.environ.get("ES_HOST", "http://elasticsearch:9200")
+ES_INDEX = os.environ.get("ES_INDEX", "index-ticks")
+
+def create_es_index(es):
+    """
+    Elasticsearch 인덱스 및 매핑 생성 (Consumer 시작 1회 실행)
+    - index_code는 집계(Aggregation)를 위해 반드시 'keyword' 타입
+    - ES에 해당 인덱스가 없다면 생성
+    """
+    if not es.indices.exists(index=ES_INDEX):
+        mapping = {
+            "mappings": {
+                "properties": {
+                    "index_code": {"type": "keyword"},  # 백엔드 terms 집계용 (text면 집계 불가 !!)
+                    "timestamp": {"type": "date"}, # Kibana 시계열 시각화 가능
+                    "current_value": {"type": "float"},
+                    "change_value": {"type": "float"},
+                    "change_rate": {"type": "float"},
+                    "volume": {"type": "long"}
+                }
+            }
+        }
+        es.indices.create(index=ES_INDEX, body=mapping)
+        logger.info(f"인덱스 생성 완료: {ES_INDEX}")
+
+def run_consumer():
+    # 1. Kafka Consumer 연결
+    logger.info(f"Kafka 연결 시도: {KAFKA_BROKER} (Topic: {TOPIC_NAME})")
+    consumer = None
+    while not consumer: # Kafka가 늦게 뜨는 상황 대응 (Docker 환경이니까)
+        try:
+            consumer = KafkaConsumer(
+                TOPIC_NAME,
+                bootstrap_servers=[KAFKA_BROKER],
+                auto_offset_reset='latest', # consumer 시작 이후 데이터만
+                enable_auto_commit=True, # 처리 후 offset 자동 커밋
+                group_id='index-consumer-group',
+                value_deserializer=lambda x: json.loads(x.decode('utf-8'))
+            )
+            logger.info("Kafka Consumer 연결 성공!")
+        except Exception as e:
+            logger.warning(f"❌ Kafka 연결 실패 (5초 후 재시도): {e}")
+            time.sleep(5)
+
+    # 2. Elasticsearch 연결
+    logger.info(f"Elasticsearch 연결 시도: {ES_HOST}")
+    es = Elasticsearch([ES_HOST])
+    while not es.ping(): # docker 환경을 위한 지연 대응
+        logger.warning("❌ ES 연결 실패 (5초 후 재시도)")
+        time.sleep(5)
+    logger.info("Elasticsearch 연결 성공!")
+
+    # 인덱스 생성
+    create_es_index(es)
+
+    # 3. 데이터 처리 루프
+    logger.info("Index Consumer 가동 시작...")
+    
+    # ES Bulk Insert 최적화: 1건씩 넣는 것보다 훨씬 빠름
+    actions = []
+    BATCH_SIZE = 10 
+
+    for message in consumer:
+        try:
+            data = message.value
+            
+            # _id를 index_code로 지정하여 "덮어쓰기(Upsert)" 처리
+            # 이렇게 하면 ES에는 항상 '최신 상태'의 문서만 남게 되어 용량과 속도 면에서 유리
+            action = {
+                "_index": ES_INDEX,
+                "_id": data.get("index_code"), 
+                "_source": data
+            }
+            actions.append(action)
+
+            if len(actions) >= BATCH_SIZE:
+                helpers.bulk(es, actions)
+                logger.info(f"{len(actions)}건 갱신 완료 (Latest: {data.get('index_code')})")
+                actions = []
+
+        except Exception as e:
+            logger.error(f"❌ 데이터 처리 중 에러: {e}")
+
+    if actions: # 종료시 남은 데이터 처리: Graceful shutdown 대비
+        helpers.bulk(es, actions)
+
+if __name__ == "__main__":
+    run_consumer()

--- a/gaemi-project/data-pjt/consumer-index/requirements.txt
+++ b/gaemi-project/data-pjt/consumer-index/requirements.txt
@@ -1,0 +1,2 @@
+kafka-python==2.0.2
+elasticsearch==8.11.0

--- a/gaemi-project/data-pjt/consumer-index/test_producer.py
+++ b/gaemi-project/data-pjt/consumer-index/test_producer.py
@@ -1,0 +1,65 @@
+import json
+import time
+import random
+from kafka import KafkaProducer
+from datetime import datetime
+
+# Docker 내부에서 실행할 것이므로 호스트는 'kafka:29092'
+BROKER = 'kafka:29092'
+TOPIC = 'index-ticks'
+
+def get_random_data():
+    timestamp = int(time.time() * 1000) # 현재 시간 (ms)
+    
+    # KOSPI (0001) 가짜 데이터
+    kospi = {
+        "index_code": "0001",
+        "timestamp": timestamp,
+        "current_value": round(random.uniform(2550.0, 2650.0), 2), # 2550 ~ 2650 사이 랜덤
+        "change_value": round(random.uniform(-20.0, 20.0), 2),
+        "change_rate": round(random.uniform(-1.5, 1.5), 2),
+        "volume": random.randint(300000, 500000)
+    }
+
+    # KOSDAQ (1001) 가짜 데이터
+    kosdaq = {
+        "index_code": "1001",
+        "timestamp": timestamp,
+        "current_value": round(random.uniform(800.0, 900.0), 2),
+        "change_value": round(random.uniform(-10.0, 10.0), 2),
+        "change_rate": round(random.uniform(-2.0, 2.0), 2),
+        "volume": random.randint(100000, 200000)
+    }
+    
+    return [kospi, kosdaq]
+
+def run_mock_producer():
+    print(f"🚀 Mock Producer 시작 (Target: {TOPIC})")
+    
+    producer = None
+    while not producer:
+        try:
+            producer = KafkaProducer(
+                bootstrap_servers=[BROKER],
+                value_serializer=lambda x: json.dumps(x).encode('utf-8')
+            )
+            print("✅ Kafka 연결 성공!")
+        except Exception as e:
+            print(f"⏳ 연결 대기 중... ({e})")
+            time.sleep(2)
+
+    try:
+        while True:
+            data_list = get_random_data()
+            for data in data_list:
+                producer.send(TOPIC, value=data)
+                print(f"Testing [Sent] {data['index_code']} : {data['current_value']}")
+            
+            time.sleep(5) 
+
+    except KeyboardInterrupt:
+        print("🛑 테스트 종료")
+        producer.close()
+
+if __name__ == "__main__":
+    run_mock_producer()

--- a/gaemi-project/docker-compose.yml
+++ b/gaemi-project/docker-compose.yml
@@ -275,6 +275,23 @@ services:
     depends_on:
       - elasticsearch
 
+  # 14. 시간 장소 Consumer (Kafka -> ES)
+  consumer-index:
+    build:
+      context: ./data-pjt/consumer-index
+    container_name: gaemi_consumer_index
+    environment:
+      - KAFKA_BROKER=kafka:29092
+      - TOPIC_NAME=index-ticks
+      - ES_HOST=http://elasticsearch:9200
+      - ES_INDEX=index-ticks
+    depends_on:
+      kafka:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+    restart: on-failure
+
 # 볼륨 정의: 컨테이너가 꺼져도 사라지지 않는 외장하드
 volumes:
   postgres_data: # DB 데이터 저장


### PR DESCRIPTION
## 📌 개요
메인 대시보드에 필수적인 **KOSPI/KOSDAQ 지수 조회 기능**을 구현했습니다.
데이터의 실시간성을 보장하기 위해 Kafka 토픽(`index-ticks`)의 데이터를 Elasticsearch로 적재하는 **전용 Consumer(`consumer-index`)**를 추가하고, 이를 조회하는 **Backend API**를 개발했습니다.

## ✨ 주요 변경 사항
- **[Feat] Backend API (`MarketIndexView`)**
  - `GET /api/v1/stocks/market-index/` 엔드포인트 추가
  - ES의 `Terms Aggregation` 쿼리를 활용하여 각 지수별 최신 틱 데이터 1건만 효율적으로 조회
  - `0001` → `KOSPI` 등 코드-이름 매핑 로직 적용
- **[Feat] Data Pipeline (`consumer-index`)**
  - Flink 대신 유지보수가 간편한 Python 기반의 Kafka Consumer 컨테이너 추가
  - `main.py`: Kafka 메시지를 수신하여 ES에 `Upsert` (덮어쓰기) 수행. 불필요한 히스토리 적재를 방지하여 스토리지 효율화
- **[Infra] Docker Compose**
  - `consumer-index` 서비스 추가 및 환경변수(Kafka, ES 호스트) 설정

## 🔍 관련 이슈
- [I-41](https://github.com/gAemI-AI/gAemI-AI/issues/41) 
 
## 🙏 To Reviewers
- **Consumer 로직:** `data-pjt/consumer-index/main.py`에서 데이터를 `_id=index_code`로 설정하여 저장하는 부분을 확인해 주세요. 이렇게 함으로써 대시보드는 항상 최신 값만 빠르게 조회할 수 있습니다.
- **Backend 매핑:** `0001`(KOSPI), `1001`(KOSDAQ) 외에 추가될 지수가 있다면 `views.py`의 `INDEX_MAP` 딕셔너리만 수정하면 됩니다.

## 🔗 문서
- [Kafka → Elasticsearch Index Consumer 설계 및 구현 배경](https://www.notion.so/Kafka-Elasticsearch-Index-Consumer-2cf0c3d3c9ea8068a0ede8a2d90a6a6c?source=copy_link)

## 🧪 테스트 방법
** kafka topic index-ticks에 데이터가 없다면 가짜 데이터를 주입해서 테스트를 해야합니다.**
1. **Mock Producer 실행 (가짜 데이터 주입)**
   ```bash
   docker exec -it gaemi_consumer_index python test_producer.py

<img width="728" height="209" alt="image" src="https://github.com/user-attachments/assets/873ef369-f6f3-49e2-af46-14fdff58e2ea" />

2. 데이터 적재 확인 (Consumer 로그)
`docker logs -f gaemi_consumer_index`

<img width="686" height="28" alt="image" src="https://github.com/user-attachments/assets/05a279b2-17cf-4c44-9852-8a506840110d" />


3. API 테스트
`curl http://localhost:8000/api/v1/stocks/market-index/`

<img width="826" height="32" alt="image" src="https://github.com/user-attachments/assets/515921ef-c146-46fc-a20e-e8d36e11b8eb" />

4. (오류 발생시) 3의 결과가 빈 배열 []을 반환하는 경우 해결 방법
- Elasticsearch의 인덱스 매핑 문제이므로 

- `curl -X DELETE "http://localhost:9200/index-ticks"`

- (예상 결과: {"acknowledged":true})

- `docker restart gaemi_consumer_index`

- `docker exec -it gaemi_consumer_index python test_producer.py`

- `curl http://localhost:8000/api/v1/stocks/market-index/`
