### PR TITLE
[I-37] (Frontend) AI 챗봇 플로팅 UI & 알림 토스트 전역 UI 구조 구현 (Pre-API) + AI 뉴스 분석 페이지 삭제 및 AI 챗봇 페이지 생성

### DIFF
--- a/gaemi-project/frontend-pjt/package-lock.json
+++ b/gaemi-project/frontend-pjt/package-lock.json
@@ -52,7 +52,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1619,7 +1618,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2370,7 +2368,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2589,7 +2586,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
         "@vue/compiler-sfc": "3.5.24",

--- a/gaemi-project/frontend-pjt/src/components/chat/AiChatWidget.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/AiChatWidget.vue
@@ -1,118 +1,49 @@
 <template>
-  <div>
-    <!-- 플로팅 버튼 -->
-    <button v-if="!open" class="floating-btn" @click="open = true">
-      💬
-    </button>
-
-    <!-- 챗봇 패널 -->
-    <div v-else class="chat-panel">
-      <header class="chat-header">
-        <div>
-          <div class="title">AI 챗봇</div>
-          <div class="subtitle">RAG 기반 분석</div>
-        </div>
-        <button class="close-btn" @click="open = false">✕</button>
-      </header>
-
-      <div class="chat-body">
-        <div class="bubble bot">
-          안녕하세요! <strong>"gAemI"</strong> AI 어시스턴트입니다. <br />
-          실시간 주가 데이터와 AI 뉴스 분석을 결합한 RAG 시스템으로 응답합니다.
-        </div>
-        <div
-          v-for="(m, idx) in messages"
-          :key="idx"
-          class="bubble"
-          :class="m.role"
-        >
-          {{ m.content }}
-        </div>
+  <div class="chat-widget">
+    <!-- 메시지 영역 -->
+    <div class="chat-body">
+      <div
+        v-for="(m, idx) in chatbotStore.messages"
+        :key="idx"
+        class="bubble"
+        :class="m.role"
+      >
+        {{ m.content }}
       </div>
-
-      <form class="chat-input" @submit.prevent="send">
-        <input
-          v-model="input"
-          type="text"
-          placeholder="예: 삼성전자 3분기 실적 어때?"
-        />
-        <button type="submit">전송</button>
-      </form>
     </div>
+
+    <!-- 입력 영역 -->
+    <form class="chat-input" @submit.prevent="send">
+      <input
+        v-model="input"
+        type="text"
+        placeholder="예: 삼성전자 3분기 실적 어때?"
+      />
+      <button type="submit">전송</button>
+    </form>
   </div>
 </template>
 
 <script setup>
-import { ref } from 'vue';
+import { ref } from "vue";
+import { useChatbotStore } from "@/stores/chatbotStore";
 
-const open = ref(false);
-const input = ref('');
-const messages = ref([]);
+const chatbotStore = useChatbotStore();
+const input = ref("");
 
 function send() {
   if (!input.value.trim()) return;
-  messages.value.push({ role: 'user', content: input.value });
-  // 실제로는 백엔드 RAG API 호출
-  messages.value.push({
-    role: 'bot',
-    content: '여기에 백엔드에서 받은 RAG 응답 내용을 표시합니다.',
-  });
-  input.value = '';
+  chatbotStore.sendMessageMock(input.value);
+  input.value = "";
 }
 </script>
 
 <style scoped>
-.floating-btn {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  width: 52px;
-  height: 52px;
-  border-radius: 999px;
-  border: none;
-  background: #2563eb;
-  color: white;
-  font-size: 24px;
-  cursor: pointer;
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
-  z-index: 50;
-}
-
-/* 패널이 떠 있어도 overlay를 깔지 않으므로,
-   패널 밖 영역은 그대로 클릭/스크롤 가능 */
-.chat-panel {
-  position: fixed;
-  right: 24px;
-  bottom: 24px;
-  width: 380px;
-  height: 460px;
-  border-radius: 16px;
-  background: white;
-  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.3);
+/* 🔑 핵심 wrapper */
+.chat-widget {
   display: flex;
   flex-direction: column;
-  z-index: 50;
-}
-
-.chat-header {
-  padding: 10px 14px;
-  border-bottom: 1px solid #e5e7eb;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.chat-header .title {
-  font-weight: 600;
-}
-.chat-header .subtitle {
-  font-size: 12px;
-  color: #6b7280;
-}
-.close-btn {
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  font-size: 18px;
+  height: 100%;
 }
 
 .chat-body {

--- a/gaemi-project/frontend-pjt/src/components/chat/AiChatWidget.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/AiChatWidget.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="chat-widget">
     <!-- 메시지 영역 -->
-    <div class="chat-body">
+    <div ref="bodyRef" class="chat-body">
       <div
-        v-for="(m, idx) in chatbotStore.messages"
-        :key="idx"
+        v-for="m in chatbotStore.messages"
+        :key="m.id || m.createdAt || m.content"
         class="bubble"
-        :class="m.role"
+        :class="bubbleClass(m.role)"
       >
         {{ m.content }}
       </div>
@@ -18,6 +18,7 @@
         v-model="input"
         type="text"
         placeholder="예: 삼성전자 3분기 실적 어때?"
+        autocomplete="off"
       />
       <button type="submit">전송</button>
     </form>
@@ -25,21 +26,37 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { ref, nextTick } from "vue";
 import { useChatbotStore } from "@/stores/chatbotStore";
 
 const chatbotStore = useChatbotStore();
 const input = ref("");
+const bodyRef = ref(null);
 
-function send() {
-  if (!input.value.trim()) return;
-  chatbotStore.sendMessageMock(input.value);
+function bubbleClass(role) {
+  // store role: "user" | "assistant" | "system"
+  if (role === "assistant") return "bot";
+  return role; // "user", "system"
+}
+
+async function send() {
+  const text = input.value.trim();
+  if (!text) return;
+
+  // ✅ store에 있는 액션 사용 (너가 올린 store에는 send(text)만 있음)
+  await chatbotStore.send(text);
+
   input.value = "";
+
+  // ✅ 전송 후 맨 아래로 스크롤
+  await nextTick();
+  if (bodyRef.value) {
+    bodyRef.value.scrollTop = bodyRef.value.scrollHeight;
+  }
 }
 </script>
 
 <style scoped>
-/* 🔑 핵심 wrapper */
 .chat-widget {
   display: flex;
   flex-direction: column;
@@ -55,21 +72,39 @@ function send() {
   flex-direction: column;
   gap: 8px;
 }
+
 .bubble {
   max-width: 80%;
   padding: 8px 10px;
   border-radius: 12px;
   font-size: 13px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
+
+/* ✅ assistant -> bot */
 .bubble.bot {
   background: white;
   align-self: flex-start;
+  border: 1px solid #e5e7eb;
 }
+
+/* ✅ user */
 .bubble.user {
   background: #2563eb;
   color: white;
   align-self: flex-end;
 }
+
+/* (선택) system 메시지 */
+.bubble.system {
+  background: white;
+  color: #111827;
+  align-self: flex-start;
+  border: 1px solid #e5e7eb;
+}
+
 
 .chat-input {
   padding: 10px;
@@ -77,13 +112,16 @@ function send() {
   display: flex;
   gap: 8px;
 }
+
 .chat-input input {
   flex: 1;
+  min-width: 0;
   border-radius: 999px;
   border: 1px solid #d1d5db;
   padding: 8px 12px;
   font-size: 13px;
 }
+
 .chat-input button {
   border-radius: 999px;
   border: none;

--- a/gaemi-project/frontend-pjt/src/components/chat/ChatbotFab.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/ChatbotFab.vue
@@ -14,9 +14,15 @@ import { useChatbotStore } from "@/stores/chatbotStore";
  */
 const chatbotStore = useChatbotStore();
 
+// const openChat = () => {
+//   chatbotStore.openChat();
+// };
 const openChat = () => {
-  chatbotStore.openChat();
+  console.log("FAB CLICK");
+  chatbotStore.open();
+  console.log("isOpen:", chatbotStore.isOpen);
 };
+
 </script>
 
 <style scoped>

--- a/gaemi-project/frontend-pjt/src/components/chat/ChatbotFab.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/ChatbotFab.vue
@@ -1,0 +1,49 @@
+<template>
+  <button class="chatbot-fab" @click="openChat">
+    💬
+  </button>
+</template>
+
+<script setup>
+import { useChatbotStore } from "@/stores/chatbotStore";
+
+/**
+ * 💬 Chatbot Floating Action Button
+ * - 챗봇을 여는 전역 플로팅 버튼
+ * - 상태 관리는 store에 위임
+ */
+const chatbotStore = useChatbotStore();
+
+const openChat = () => {
+  chatbotStore.openChat();
+};
+</script>
+
+<style scoped>
+.chatbot-fab {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+
+  width: 52px;
+  height: 52px;
+  border-radius: 999px;
+  border: none;
+
+  background: #2563eb;
+  color: #ffffff;
+  font-size: 24px;
+
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+  z-index: 40;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chatbot-fab:hover {
+  background: #1d4ed8;
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/components/chat/ChatbotPanel.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/ChatbotPanel.vue
@@ -29,7 +29,7 @@ import AiChatWidget from "@/components/chat/AiChatWidget.vue";
 const chatbotStore = useChatbotStore();
 
 const closeChat = () => {
-  chatbotStore.closeChat();
+  chatbotStore.close();
 };
 </script>
 

--- a/gaemi-project/frontend-pjt/src/components/chat/ChatbotPanel.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/ChatbotPanel.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="chatbot-panel">
+    <!-- 헤더 -->
+    <header class="panel-header">
+      <div class="header-text">
+        <div class="title">AI 챗봇</div>
+        <div class="subtitle">RAG 기반 분석</div>
+      </div>
+      <button class="close-btn" @click="closeChat">✕</button>
+    </header>
+
+    <!-- 본문: 기존 AI 챗봇 UI -->
+    <div class="panel-body">
+      <AiChatWidget />
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useChatbotStore } from "@/stores/chatbotStore";
+import AiChatWidget from "@/components/chat/AiChatWidget.vue";
+
+/**
+ * 🤖 Chatbot Panel
+ * - 전역 챗봇 패널 컨테이너
+ * - 열림/닫힘은 store에서 제어
+ * - 내부 UI는 AiChatWidget에 위임
+ */
+const chatbotStore = useChatbotStore();
+
+const closeChat = () => {
+  chatbotStore.closeChat();
+};
+</script>
+
+<style scoped>
+.chatbot-panel {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+
+  width: 380px;
+  height: 460px;
+  border-radius: 16px;
+
+  background: #ffffff;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.3);
+
+  display: flex;
+  flex-direction: column;
+
+  z-index: 45;
+}
+
+/* 헤더 */
+.panel-header {
+  padding: 10px 14px;
+  border-bottom: 1px solid #e5e7eb;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.header-text .title {
+  font-weight: 600;
+}
+.header-text .subtitle {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.close-btn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+/* 본문 */
+.panel-body {
+  flex: 1;
+  overflow: hidden;
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/components/chat/ChatbotPanel.vue
+++ b/gaemi-project/frontend-pjt/src/components/chat/ChatbotPanel.vue
@@ -49,7 +49,7 @@ const closeChat = () => {
   display: flex;
   flex-direction: column;
 
-  z-index: 45;
+  z-index: 80;
 }
 
 /* 헤더 */
@@ -82,4 +82,5 @@ const closeChat = () => {
   flex: 1;
   overflow: hidden;
 }
+
 </style>

--- a/gaemi-project/frontend-pjt/src/components/dashboard/AlertHistoryList.vue
+++ b/gaemi-project/frontend-pjt/src/components/dashboard/AlertHistoryList.vue
@@ -1,14 +1,17 @@
 <template>
   <div class="alert-panel">
     <header class="header">
-      <span>알림 내역</span>
+      <span>알림 조건 목록</span>
       <span class="count">{{ alerts.length }}개</span>
     </header>
 
+    <!-- 🔔 스크롤은 여기만 -->
     <div class="list">
       <div v-for="alert in alerts" :key="alert.id" class="item">
         <div class="left">
-          <div class="badge" :class="alert.statusClass">{{ alert.stockName }}</div>
+          <div class="badge" :class="alert.statusClass">
+            {{ alert.stockName }}
+          </div>
           <div class="title">{{ alert.title }}</div>
           <div class="time">{{ alert.time }}</div>
         </div>
@@ -29,29 +32,43 @@ defineProps({
   border-radius: 16px;
   padding: 16px;
   border: 1px solid #e5e7eb;
-  height: 100%;
+
+  /* ⭐ 핵심 */
   display: flex;
   flex-direction: column;
 }
+
+/* 헤더는 고정 */
 .header {
   display: flex;
   justify-content: space-between;
   margin-bottom: 12px;
   font-size: 14px;
 }
+
 .count {
   color: #9ca3af;
 }
+
+/* 🔥 스크롤 영역 */
 .list {
   display: flex;
   flex-direction: column;
   gap: 10px;
+
+  /* ⭐ 여기만 스크롤 */
+  overflow-y: auto;
+  max-height: 360px; /* ← 원하는 높이로 조절 */
+  padding-right: 4px;
 }
+
+/* 아이템 */
 .item {
   padding: 10px 12px;
   border-radius: 10px;
   background: #f9fafb;
 }
+
 .badge {
   display: inline-flex;
   padding: 2px 8px;
@@ -60,12 +77,15 @@ defineProps({
   margin-bottom: 4px;
   color: white;
 }
+
 .badge.working {
   background: #2563eb;
 }
+
 .title {
   font-size: 13px;
 }
+
 .time {
   margin-top: 2px;
   font-size: 11px;

--- a/gaemi-project/frontend-pjt/src/components/dashboard/MarketSummaryPanel.vue
+++ b/gaemi-project/frontend-pjt/src/components/dashboard/MarketSummaryPanel.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="market-panel">
+    <h3 class="panel-title">시장 지수</h3>
+
+    <div class="market-cards">
+      <!-- 코스피 -->
+      <div class="market-card">
+        <div class="label">코스피</div>
+        <div class="price">{{ market.kospi.price.toLocaleString() }}</div>
+        <div
+          class="diff"
+          :class="{ up: market.kospi.diff >= 0, down: market.kospi.diff < 0 }"
+        >
+          <span>
+            {{ market.kospi.diff >= 0 ? "▲" : "▼" }}
+            {{ market.kospi.diff }}
+          </span>
+          <span>({{ market.kospi.rate }}%)</span>
+        </div>
+      </div>
+
+      <!-- 코스닥 -->
+      <div class="market-card">
+        <div class="label">코스닥</div>
+        <div class="price">{{ market.kosdaq.price.toLocaleString() }}</div>
+        <div
+          class="diff"
+          :class="{ up: market.kosdaq.diff >= 0, down: market.kosdaq.diff < 0 }"
+        >
+          <span>
+            {{ market.kosdaq.diff >= 0 ? "▲" : "▼" }}
+            {{ market.kosdaq.diff }}
+          </span>
+          <span>({{ market.kosdaq.rate }}%)</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { onMounted } from "vue";
+import { useMarketStore } from "@/stores/marketStore";
+
+const market = useMarketStore();
+
+onMounted(() => {
+  market.loadMock(); // 🔹 지금은 더미
+});
+</script>
+
+<style scoped>
+.market-panel {
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+  margin-bottom: 16px;
+}
+
+.panel-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+/* 카드 2개 */
+.market-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.market-card {
+  background: #f9fafb;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.label {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.price {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 4px 0;
+}
+
+.diff {
+  font-size: 13px;
+  display: flex;
+  gap: 6px;
+}
+
+.diff.up {
+  color: #ef4444;
+}
+
+.diff.down {
+  color: #2563eb;
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/components/layout/AuthLayout.vue
+++ b/gaemi-project/frontend-pjt/src/components/layout/AuthLayout.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="auth-layout">
+    <RouterView />
+  </div>
+</template>
+
+<script setup>
+import { RouterView } from "vue-router";
+</script>
+
+<style>
+.auth-layout {
+  min-height: 100vh;
+  background: #f5f6fa;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* ✅ 깨지는 input들 공통 해결 */
+.auth-layout input {
+  min-width: 0;     /* flex overflow 방지 */
+  width: auto;      /* width:100% 덮어쓰기 */
+  flex: 1;          /* 버튼/아이콘 옆에서 정상 축소 */
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
+++ b/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
@@ -51,8 +51,36 @@
 
         <!-- 오른쪽 영역 -->
         <div class="right-icons">
-          <button class="icon-btn">🔔</button>
-          <button class="icon-btn">⚙️</button>
+          <button class="icon-btn bell-btn" @click="bellOpen = !bellOpen">🔔</button>
+          <div v-if="bellOpen" class="alert-dropdown">
+            <!-- 헤더 -->
+            <div class="alert-head">
+              <span class="title">알림</span>
+              <span class="count">{{ alertEventsStore.count }}개</span>
+            </div>
+
+            <!-- 리스트 -->
+            <div class="alert-list" v-if="alertEventsStore.latestEvents.length > 0">
+              <div
+                v-for="ev in alertEventsStore.latestEvents.slice(0, 20)"
+                :key="ev.id"
+                class="alert-item"
+              >
+                <div class="alert-main">
+                  <span class="stock">{{ ev.stockName }}</span>
+                  <span class="msg">
+                    {{ formatCondition(ev.condition, ev.target) }}
+                  </span>
+                </div>
+                <div class="time">{{ formatTime(ev.triggeredAt) }}</div>
+              </div>
+            </div>
+
+            <!-- 비었을 때 -->
+            <div v-else class="empty">
+              아직 알림이 없어요.
+            </div>
+          </div>
 
           <!-- 로그인 안됨 -->
           <RouterLink v-if="!user" to="/login" class="login-btn">
@@ -82,19 +110,21 @@
     <!-- =========================
          전역 UI (layout-root 밖)
     ========================== -->
-    <ToastStack v-if="toastStore.toasts.length > 0" />
+    <ToastStack v-if="showToastsHere && toastStore.toasts.length > 0" />
     <ChatbotFab />
     <ChatbotPanel v-if="chatbotStore.isOpen" />
 
 </template>
 
 <script setup>
-import { RouterView, RouterLink, useRouter } from "vue-router";
-import { ref, onMounted } from "vue";
+import { RouterView, RouterLink, useRouter, useRoute } from "vue-router";
+import { ref, onMounted, onUnmounted, watch, computed } from "vue";
 
 import { useFavoritesStore } from "@/stores/favoritesStore.js";
 import { useChatbotStore } from "@/stores/chatbotStore";
 import { useToastStore } from "@/stores/toastStore";
+
+import { useAlertEventsStore } from "@/stores/alertEventsStore";
 
 import ChatbotFab from "@/components/chat/ChatbotFab.vue";
 import ChatbotPanel from "@/components/chat/ChatbotPanel.vue";
@@ -104,18 +134,110 @@ const favoritesStore = useFavoritesStore();
 const chatbotStore = useChatbotStore();
 const toastStore = useToastStore();
 
+const alertEventsStore = useAlertEventsStore();
+
 const router = useRouter();
+const route = useRoute();
+
 const dropdownOpen = ref(false);
 const user = ref(null);
+const bellOpen = ref(false);
+
+/** ✅ 토스트를 보여줄 페이지 제한
+ * - /app/dashboard, /app/chatbot, /app/alerts 에서만 토스트 표시
+ */
+const showToastsHere = computed(() => {
+  const p = route.path;
+  return (
+    p.startsWith("/app/dashboard") ||
+    p.startsWith("/app/chatbot") ||
+    p.startsWith("/app/alerts")
+  );
+});
+
+/** ✅ (핵심) user별 마지막 토스트 처리 시점 저장 키 */
+const lastToastKey = computed(() => {
+  const username = user.value?.username;
+  return username ? `last_toast_at_${username}` : null;
+});
+
+/** ✅ 이벤트 1개를 토스트로 변환 */
+function toastFromEvent(ev) {
+  return {
+    type: "info",
+    title: "알림 도착",
+    // event 구조에 맞춰 메시지 구성 (현재 alertEventsStore 예시 기반)
+    message: `${ev.stockName} · ${ev.target}${ev.condition === "changeUp" || ev.condition === "changeDown" ? "%" : "원"} 조건 충족`,
+  };
+}
+function formatCondition(condition, target) {
+  switch (condition) {
+    case "gte":
+      return `${target}원 이상`;
+    case "lte":
+      return `${target}원 이하`;
+    case "changeUp":
+      return `${target}% 이상`;
+    case "changeDown":
+      return `${target}% 이하`;
+    default:
+      return "";
+  }
+}
+
+function formatTime(iso) {
+  const d = new Date(iso);
+  return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
+/** ✅ 로그인 직후/새 이벤트 도착 시, "안 띄운 이벤트만" 토스트로 띄우기 */
+function flushUnshownEvents() {
+  if (!user.value?.isLogin) return;                 // 로그인 상태 아니면 토스트 X
+  if (!lastToastKey.value) return;
+
+  const lastShownAt = localStorage.getItem(lastToastKey.value); // ISO string or null
+
+  // 내 이벤트만 (나중에 서버 붙이면 event에 username/userId 필수)
+  const myEvents = alertEventsStore.latestEvents;
+
+  const newOnes = myEvents.filter((ev) => {
+    if (!lastShownAt) return true;
+    // triggeredAt이 lastShownAt 이후인 것만
+    return new Date(ev.triggeredAt) > new Date(lastShownAt);
+  });
+
+  // 오래된 것부터 순서대로 토스트 띄우기 (FIFO 자연스럽게)
+  newOnes
+    .slice()
+    .sort((a, b) => new Date(a.triggeredAt) - new Date(b.triggeredAt))
+    .forEach((ev) => toastStore.push(toastFromEvent(ev)));
+
+  // 마지막으로 처리한 시점 갱신 (가장 최신 이벤트 기준)
+  if (newOnes.length > 0) {
+    const newest = newOnes.reduce((acc, cur) =>
+      new Date(cur.triggeredAt) > new Date(acc.triggeredAt) ? cur : acc
+    );
+    localStorage.setItem(lastToastKey.value, newest.triggeredAt);
+  }
+}
 
 onMounted(() => {
   favoritesStore.loadFromLocal();
 
   const saved = localStorage.getItem("user");
-  if (saved) {
-    user.value = JSON.parse(saved);
-  }
+  if (saved) user.value = JSON.parse(saved);
+
+  // ✅ 로그인 후 들어왔을 때: "쌓인 알림" 토스트로 한번에 처리
+  flushUnshownEvents();
 });
+
+// ✅ 새 이벤트가 들어올 때마다 토스트 처리
+watch(
+  () => alertEventsStore.events.length,
+  () => {
+    flushUnshownEvents();
+  }
+);
 
 const toggleDropdown = () => {
   dropdownOpen.value = !dropdownOpen.value;
@@ -127,7 +249,25 @@ const logout = () => {
   alert("로그아웃 되었습니다.");
   router.push("/login");
 };
+
+function closeBell(e) {
+  // 클릭한 곳이 종버튼/드롭다운 내부면 닫지 않음
+  if (e.target.closest(".alert-dropdown")) return;
+  if (e.target.closest(".bell-btn")) return;
+
+  bellOpen.value = false;
+}
+
+onMounted(() => {
+  document.addEventListener("click", closeBell);
+});
+
+onUnmounted(() => {
+  document.removeEventListener("click", closeBell);
+});
+
 </script>
+
 
 <style scoped>
 .layout-root {
@@ -279,4 +419,93 @@ const logout = () => {
   padding: 20px 40px;
   box-sizing: border-box;
 }
+/* 🔔 알림 드롭다운 */
+.alert-dropdown {
+  position: absolute;
+  top: 44px;          /* 종 버튼 바로 아래 */
+  right: 0;
+  width: 320px;
+  max-height: 420px;
+
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.12);
+
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 100;
+}
+
+/* 헤더 */
+.alert-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  padding: 12px 16px;
+  border-bottom: 1px solid #f1f5f9;
+  font-weight: 600;
+}
+
+.alert-head .title {
+  font-size: 14px;
+}
+
+.alert-head .count {
+  font-size: 12px;
+  color: #2563eb;
+}
+
+/* 리스트 */
+.alert-list {
+  overflow-y: auto;
+}
+
+/* 개별 알림 */
+.alert-item {
+  padding: 12px 16px;
+  border-bottom: 1px solid #f1f5f9;
+  cursor: pointer;
+}
+
+.alert-item:hover {
+  background: #f8fafc;
+}
+
+.alert-main {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.stock {
+  font-size: 12px;
+  font-weight: 600;
+  color: #2563eb;
+  background: #eef2ff;
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.msg {
+  font-size: 13px;
+  color: #374151;
+}
+
+.time {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #9ca3af;
+}
+
+/* 비었을 때 */
+.empty {
+  padding: 24px;
+  text-align: center;
+  font-size: 13px;
+  color: #9ca3af;
+}
+
 </style>

--- a/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
+++ b/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
@@ -1,72 +1,82 @@
 <template>
-  <div class="layout-root">
-    <header class="top-bar">
-      <!-- 로고 -->
-      <div class="logo-area">
-        <img src="@/assets/logo/gaemi.png" class="logo-img" />
-        <div class="logo-text">
-          <div class="title">gAemI</div>
-          <div class="subtitle">시간 없는 개미를 위한 AI 투자 파트너</div>
-        </div>
-      </div>
-
-      <!-- 탭 -->
-      <nav class="nav-tabs">
-        <RouterLink
-          to="/app/dashboard"
-          class="tab"
-          :class="{ active: $route.path.startsWith('/app/dashboard') }"
-        >
-          대시보드
-        </RouterLink>
-
-        <RouterLink
-          to="/app/ai-news"
-          class="tab"
-          :class="{ active: $route.path.startsWith('/app/ai-news') }"
-        >
-          AI 뉴스 분석
-        </RouterLink>
-
-        <RouterLink
-          to="/app/alerts"
-          class="tab"
-          :class="{ active: $route.path.startsWith('/app/alerts') }"
-        >
-          알림 관리
-        </RouterLink>
-      </nav>
-
-      <!-- 오른쪽 영역 -->
-      <div class="right-icons">
-        <button class="icon-btn">🔔</button>
-        <button class="icon-btn">⚙️</button>
-
-        <!-- 로그인 안됨 -->
-        <RouterLink v-if="!user" to="/login" class="login-btn">
-          로그인
-        </RouterLink>
-
-        <!-- 로그인 됨 -->
-        <div v-else class="user-area">
-          <span class="username" @click="toggleDropdown">
-            {{ user.nickname }}
-          </span>
-
-          <!-- ↓ 닉네임 클릭 시 나오는 박스 -->
-          <div v-if="dropdownOpen" class="dropdown-box">
-            <p class="nickname-display">@{{ user.username }}</p>
-            <button class="logout-btn" @click="logout">로그아웃</button>
+    <!-- =========================
+         기존 레이아웃 (원본 유지)
+    ========================== -->
+    <div class="layout-root">
+      <header class="top-bar">
+        <!-- 로고 -->
+        <div class="logo-area">
+          <img src="@/assets/logo/gaemi.png" class="logo-img" />
+          <div class="logo-text">
+            <div class="title">gAemI</div>
+            <div class="subtitle">시간 없는 개미를 위한 AI 투자 파트너</div>
           </div>
         </div>
-      </div>
-    </header>
 
-    <!-- 컨텐츠 -->
-    <main class="main-content">
-      <RouterView />
-    </main>
-  </div>
+        <!-- 탭 -->
+        <nav class="nav-tabs">
+          <RouterLink
+            to="/app/dashboard"
+            class="tab"
+            :class="{ active: $route.path.startsWith('/app/dashboard') }"
+          >
+            대시보드
+          </RouterLink>
+
+          <RouterLink
+            to="/app/ai-news"
+            class="tab"
+            :class="{ active: $route.path.startsWith('/app/ai-news') }"
+          >
+            AI 뉴스 분석
+          </RouterLink>
+
+          <RouterLink
+            to="/app/alerts"
+            class="tab"
+            :class="{ active: $route.path.startsWith('/app/alerts') }"
+          >
+            알림 관리
+          </RouterLink>
+        </nav>
+
+        <!-- 오른쪽 영역 -->
+        <div class="right-icons">
+          <button class="icon-btn">🔔</button>
+          <button class="icon-btn">⚙️</button>
+
+          <!-- 로그인 안됨 -->
+          <RouterLink v-if="!user" to="/login" class="login-btn">
+            로그인
+          </RouterLink>
+
+          <!-- 로그인 됨 -->
+          <div v-else class="user-area">
+            <span class="username" @click="toggleDropdown">
+              {{ user.nickname }}
+            </span>
+
+            <div v-if="dropdownOpen" class="dropdown-box">
+              <p class="nickname-display">@{{ user.username }}</p>
+              <button class="logout-btn" @click="logout">로그아웃</button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <!-- 컨텐츠 -->
+      <main class="main-content">
+        <RouterView />
+      </main>
+    </div>
+
+    <!-- =========================
+         전역 UI (layout-root 밖)
+    ========================== -->
+    <ToastStack v-if="toastStore.toasts.length > 0" />
+    <ChatbotFab v-if="!chatbotStore.isOpen" />
+    <ChatbotPanel v-show="chatbotStore.isOpen" />
+
 </template>
 
 <script setup>
@@ -74,42 +84,37 @@ import { RouterView, RouterLink, useRouter } from "vue-router";
 import { ref, onMounted } from "vue";
 
 import { useFavoritesStore } from "@/stores/favoritesStore.js";
+import { useChatbotStore } from "@/stores/chatbotStore";
+import { useToastStore } from "@/stores/toastStore";
+
+import ChatbotFab from "@/components/chat/ChatbotFab.vue";
+import ChatbotPanel from "@/components/chat/ChatbotPanel.vue";
+import ToastStack from "@/components/toast/ToastStack.vue";
 
 const favoritesStore = useFavoritesStore();
-
-onMounted(() => {
-  favoritesStore.loadFromLocal();
-});
-
+const chatbotStore = useChatbotStore();
+const toastStore = useToastStore();
 
 const router = useRouter();
 const dropdownOpen = ref(false);
 const user = ref(null);
 
-/* ---------------------------
-   로그인 정보 불러오기
---------------------------- */
 onMounted(() => {
+  favoritesStore.loadFromLocal();
+
   const saved = localStorage.getItem("user");
   if (saved) {
     user.value = JSON.parse(saved);
   }
 });
 
-/* ---------------------------
-   드롭다운 토글
---------------------------- */
 const toggleDropdown = () => {
   dropdownOpen.value = !dropdownOpen.value;
 };
 
-/* ---------------------------
-   로그아웃
---------------------------- */
 const logout = () => {
   localStorage.removeItem("user");
   dropdownOpen.value = false;
-
   alert("로그아웃 되었습니다.");
   router.push("/login");
 };
@@ -163,7 +168,8 @@ const logout = () => {
   display: flex;
   gap: 16px;
   justify-content: center;
-  width: 1400px;
+  width: 100%;
+  max-width: 1400px;
 }
 .tab {
   padding: 6px 12px;
@@ -262,5 +268,6 @@ const logout = () => {
   max-width: 1400px;
   margin: 0 auto;
   padding: 20px 40px;
+  box-sizing: border-box;
 }
 </style>

--- a/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
+++ b/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
@@ -227,6 +227,14 @@ onMounted(() => {
   const saved = localStorage.getItem("user");
   if (saved) user.value = JSON.parse(saved);
 
+  chatbotStore.loadFromLocal();
+
+  if (
+    chatbotStore.messages.length > 0 &&
+    route.path.startsWith("/app/chatbot")
+  ) {
+    chatbotStore.isOpen = true;
+  }
   // ✅ 로그인 후 들어왔을 때: "쌓인 알림" 토스트로 한번에 처리
   flushUnshownEvents();
 });

--- a/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
+++ b/gaemi-project/frontend-pjt/src/components/layout/MainLayout.vue
@@ -23,13 +23,22 @@
             대시보드
           </RouterLink>
 
-          <RouterLink
+          <!-- <RouterLink
             to="/app/ai-news"
             class="tab"
             :class="{ active: $route.path.startsWith('/app/ai-news') }"
           >
             AI 뉴스 분석
+          </RouterLink> -->
+          
+          <RouterLink
+            to="/app/chatbot"
+            class="tab"
+            :class="{ active: $route.path.startsWith('/app/chatbot') }"
+          >
+            AI 챗봇
           </RouterLink>
+
 
           <RouterLink
             to="/app/alerts"
@@ -74,8 +83,8 @@
          전역 UI (layout-root 밖)
     ========================== -->
     <ToastStack v-if="toastStore.toasts.length > 0" />
-    <ChatbotFab v-if="!chatbotStore.isOpen" />
-    <ChatbotPanel v-show="chatbotStore.isOpen" />
+    <ChatbotFab />
+    <ChatbotPanel v-if="chatbotStore.isOpen" />
 
 </template>
 

--- a/gaemi-project/frontend-pjt/src/components/toast/ToastItem.vue
+++ b/gaemi-project/frontend-pjt/src/components/toast/ToastItem.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="toast-item" :class="toast.type">
+    <div class="message">
+      {{ toast.message }}
+    </div>
+
+    <button class="close-btn" @click="$emit('close')">
+      ✕
+    </button>
+  </div>
+</template>
+
+<script setup>
+/**
+ * 🔔 Toast Item
+ * - 토스트 1개의 UI
+ * - 닫기 버튼 클릭 시 close 이벤트 emit
+ */
+defineProps({
+  toast: {
+    type: Object,
+    required: true,
+  },
+});
+
+defineEmits(["close"]);
+</script>
+
+<style scoped>
+.toast-item {
+  min-width: 260px;
+  max-width: 360px;
+
+  padding: 12px 14px;
+  border-radius: 12px;
+
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
+
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  font-size: 13px;
+}
+
+/* 메시지 */
+.message {
+  color: #111827;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+/* 닫기 버튼 */
+.close-btn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 14px;
+  color: #9ca3af;
+}
+.close-btn:hover {
+  color: #374151;
+}
+
+/* 타입별 스타일 (선택) */
+.toast-item.info {
+  border-left: 4px solid #2563eb;
+}
+.toast-item.success {
+  border-left: 4px solid #16a34a;
+}
+.toast-item.error {
+  border-left: 4px solid #dc2626;
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/components/toast/ToastStack.vue
+++ b/gaemi-project/frontend-pjt/src/components/toast/ToastStack.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="toast-stack">
+    <div
+      v-for="toast in toastStore.toasts"
+      :key="toast.id"
+      class="toast"
+      :class="toast.type"
+    >
+      <div class="title">{{ toast.title }}</div>
+      <div class="message">{{ toast.message }}</div>
+
+      <button class="close" @click="toastStore.remove(toast.id)">✕</button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { useToastStore } from "@/stores/toastStore";
+
+const toastStore = useToastStore();
+</script>
+
+<style scoped>
+.toast-stack {
+  position: fixed;
+  right: 24px;
+  bottom: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 60;
+}
+
+.toast {
+  background: white;
+  border-radius: 12px;
+  padding: 12px 14px;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.15);
+  width: 260px;
+  position: relative;
+}
+
+.toast.info {
+  border-left: 4px solid #2563eb;
+}
+
+.toast.warning {
+  border-left: 4px solid #f59e0b;
+}
+
+.toast.error {
+  border-left: 4px solid #ef4444;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.message {
+  font-size: 12px;
+  color: #4b5563;
+  margin-top: 4px;
+}
+
+.close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/main.js
+++ b/gaemi-project/frontend-pjt/src/main.js
@@ -1,14 +1,12 @@
-import './assets/main.css'
+import { createApp } from "vue";
+import { createPinia } from "pinia";
 
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
+import App from "./App.vue";
+import router from "./router";
 
-import App from './App.vue'
-import router from './router'
+const app = createApp(App);
+const pinia = createPinia();
 
-const app = createApp(App)
-
-app.use(createPinia())
-app.use(router)
-
-app.mount('#app')
+app.use(pinia);     // ⭐ 이게 핵심
+app.use(router);
+app.mount("#app");

--- a/gaemi-project/frontend-pjt/src/pages/ChatbotPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/ChatbotPage.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="chatbot-page">
+    <!-- 헤더 -->
+    <header class="page-header">
+      <h1>AI 챗봇</h1>
+      <p class="desc">RAG 기반 주식·뉴스 분석</p>
+    </header>
+
+    <!-- 채팅 영역 -->
+    <section class="chat-area">
+      <AiChatWidget />
+    </section>
+  </div>
+</template>
+
+<script setup>
+import AiChatWidget from "@/components/chat/AiChatWidget.vue";
+</script>
+
+<style scoped>
+.chatbot-page {
+  height: calc(100vh - 88px); /* 상단 헤더 높이 제외 */
+  display: flex;
+  flex-direction: column;
+}
+
+/* 페이지 상단 */
+.page-header {
+  padding: 12px 0 16px;
+}
+
+.page-header h1 {
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.page-header .desc {
+  font-size: 13px;
+  color: #6b7280;
+}
+
+/* 🔥 채팅 영역이 화면을 채우게 만드는 핵심 */
+.chat-area {
+  flex: 1;                 /* 남은 높이 전부 차지 */
+  display: flex;
+  flex-direction: column;
+  min-height: 0;           /* overflow 필수 */
+}
+</style>

--- a/gaemi-project/frontend-pjt/src/pages/DashboardPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/DashboardPage.vue
@@ -6,7 +6,9 @@
     <!-- 🔍 검색창 -->
     <!-- --------------------------------------- -->
     <section class="left-column">
-      <StockSearchBar @search="onSearch" />
+      <div class='search-bar-wrapper'>
+        <StockSearchBar @search="onSearch" />
+      </div>
 
       <!-- 🔎 검색 결과 -->
       <div v-if="searchKeyword" class="search-results">
@@ -53,7 +55,8 @@
     <!-- 오른쪽 알림 패널 -->
     <!-- --------------------------------------- -->
     <aside class="right-column">
-      <AlertHistoryList :alerts="alerts" />
+      <MarketSummaryPanel />
+      <AlertHistoryList :alerts="alertsStore.alertEvents" />
     </aside>
 
   </div>
@@ -62,33 +65,36 @@
 <script setup>
 import { ref, computed, onMounted } from "vue";
 import { useFavoritesStore } from "@/stores/favoritesStore.js";
+import { useAlertsStore } from "@/stores/alertsStore";
 
 import StockSearchBar from "@/components/dashboard/StockSearchBar.vue";
 import StockTickerRow from "@/components/dashboard/StockTickerRow.vue";
 import StockDetailCard from "@/components/dashboard/StockDetailCard.vue";
 import AlertHistoryList from "@/components/dashboard/AlertHistoryList.vue";
 import FavoriteButton from "@/components/common/FavoriteButton.vue";
+import MarketSummaryPanel from "@/components/dashboard/MarketSummaryPanel.vue";
 
 /* Pinia Store */
 const store = useFavoritesStore();
 
-// 🔔 더미 알림 데이터 추가
-const alerts = ref([
-  {
-    id: 1,
-    statusClass: "working",
-    stockName: "삼성전자",
-    title: "목표가 도달했습니다.",
-    time: "10:32",
-  },
-  {
-    id: 2,
-    statusClass: "done",
-    stockName: "NAVER",
-    title: "지정가 이하로 하락했습니다.",
-    time: "09:15",
-  },
-]);
+// // 🔔 더미 알림 데이터 추가
+// const alerts = ref([
+//   {
+//     id: 1,
+//     statusClass: "working",
+//     stockName: "삼성전자",
+//     title: "목표가 도달했습니다.",
+//     time: "10:32",
+//   },
+//   {
+//     id: 2,
+//     statusClass: "done",
+//     stockName: "NAVER",
+//     title: "지정가 이하로 하락했습니다.",
+//     time: "09:15",
+//   },
+// ]);
+const alertsStore = useAlertsStore();
 
 /* ------------------------------- */
 /* 로그인 유저 관심종목 불러오기   */
@@ -170,12 +176,13 @@ function onSelectFromFavorite(stock) {
 }
 </script>
 
-
 <style scoped>
 .page-container {
   width: 100%;
   display: grid;
-  grid-template-columns: 3fr 1.2fr;
+
+  /* 🔧 핵심: grid overflow 방지 */
+  grid-template-columns: minmax(0, 3fr) minmax(0, 1.2fr);
   gap: 20px;
 }
 
@@ -184,21 +191,45 @@ function onSelectFromFavorite(stock) {
   flex-direction: column;
 }
 
+.right-column {
+  margin-left: 24px;
+  min-width: 0;
+
+  /* ⭐ 추가 */
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  /* 오른쪽 컬럼 자체는 스크롤 ❌ */
+  height: calc(100vh - 64px - 40px); 
+}
+
+
+/* 🔍 검색 결과 */
 .search-results {
-  margin-top: 16px;
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
 }
 
+/* ⭐ 관심종목 영역 */
 .favorite-section {
-  margin-top: 24px;
+  margin-top: 8px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
+/* 📈 차트 카드 */
 .chart-box {
   margin-top: 24px;
   padding: 24px;
   width: 100%;
+  max-width: 100%;
   background: white;
   border-radius: 12px;
   border: 1px solid #e5e7eb;
+  box-sizing: border-box;
 }
 
 .chart-header {
@@ -208,13 +239,14 @@ function onSelectFromFavorite(stock) {
   margin-bottom: 12px;
 }
 
-.right-column {
-  min-width: 280px;
-}
-
+/* 📱 반응형 */
 @media (max-width: 1024px) {
   .page-container {
     grid-template-columns: 1fr;
   }
 }
+.search-bar-wrapper {
+  margin-bottom: 8px; /* ← 여기서 간격 조절 */
+}
+
 </style>

--- a/gaemi-project/frontend-pjt/src/pages/LoginPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/LoginPage.vue
@@ -63,6 +63,10 @@ import { useRouter } from "vue-router";
 
 import eyeOpen from "@/assets/icons/eye-open.png";
 import eyeClosed from "@/assets/icons/eye-closed.png";
+import { useAlertEventsStore } from "@/stores/alertEventsStore";
+
+const alertEventsStore = useAlertEventsStore();
+
 
 const router = useRouter();
 const showPw = ref(false);
@@ -118,6 +122,67 @@ const onSubmit = () => {
       isLogin: true,
     })
   );
+
+  // ===============================
+  // 🔔 [임시] 로그인 시 서버에서 내려온 알림 이벤트 mock
+  // - 나중에 WebSocket / API로 대체될 부분
+  // ===============================
+  const mockAlertEvents = [
+    {
+      stockCode: "005930",
+      stockName: "삼성전자",
+      condition: "gte",
+      target: 80000,
+      currentPrice: 80100,
+      triggeredAt: "2025-12-16T09:01:00",
+    },
+    {
+      stockCode: "000660",
+      stockName: "SK하이닉스",
+      condition: "gte",
+      target: 150000,
+      currentPrice: 151200,
+      triggeredAt: "2025-12-16T09:02:00",
+    },
+    {
+      stockCode: "035420",
+      stockName: "NAVER",
+      condition: "lte",
+      target: 210000,
+      currentPrice: 208000,
+      triggeredAt: "2025-12-16T09:03:00",
+    },
+    {
+      stockCode: "005380",
+      stockName: "현대차",
+      condition: "gte",
+      target: 200000,
+      currentPrice: 201500,
+      triggeredAt: "2025-12-16T09:04:00",
+    },
+    {
+      stockCode: "006400",
+      stockName: "삼성SDI",
+      condition: "lte",
+      target: 380000,
+      currentPrice: 379000,
+      triggeredAt: "2025-12-16T09:05:00",
+    },
+    {
+      stockCode: "068270",
+      stockName: "셀트리온",
+      condition: "gte",
+      target: 180000,
+      currentPrice: 181000,
+      triggeredAt: "2025-12-16T09:06:00",
+    },
+  ];
+
+  // store에 이벤트 적재 (토스트는 MainLayout에서 처리됨)
+  mockAlertEvents.forEach(ev => {
+    alertEventsStore.addEvent(ev);
+  });
+
 
   alert("로그인 성공!"); // ✅ 이거 다시 추가
   router.push("/app/dashboard");

--- a/gaemi-project/frontend-pjt/src/pages/LoginPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/LoginPage.vue
@@ -1,9 +1,14 @@
 <template>
   <div class="auth-page">
     <div class="auth-card small">
+      <!-- 로고 -->
       <img src="@/assets/logo/gaemi.png" class="auth-logo" />
-      <h1 class="title">로그인</h1>
-      <p class="subtitle">시간 없는 개미를 위한 AI 투자 파트너</p>
+
+      <!-- 타이틀 -->
+      <div class="header">
+        <h1 class="title">로그인</h1>
+        <p class="subtitle">시간 없는 개미를 위한 AI 투자 파트너</p>
+      </div>
 
       <form class="form" @submit.prevent="onSubmit">
         <!-- 아이디 -->
@@ -18,25 +23,27 @@
         </div>
 
         <!-- 비밀번호 -->
-        <div class="input-row">
-          <input
-            :type="showPw ? 'text' : 'password'"
-            v-model="form.password"
-            placeholder="비밀번호"
-            required
-          />
-          <button
-            type="button"
-            class="icon-btn"
-            @click="showPw = !showPw"
-          >
-            <img
-              :src="showPw ? eyeClosed : eyeOpen"
-              class="eye-icon"
+        <div class="field">
+          <label>비밀번호</label>
+          <div class="input-wrapper">
+            <input
+              :type="showPw ? 'text' : 'password'"
+              v-model="form.password"
+              placeholder="비밀번호"
+              required
             />
-          </button>
+            <button
+              type="button"
+              class="icon-btn"
+              @click="showPw = !showPw"
+            >
+              <img
+                :src="showPw ? eyeClosed : eyeOpen"
+                class="eye-icon"
+              />
+            </button>
+          </div>
         </div>
-
 
         <button class="primary-btn">로그인</button>
       </form>
@@ -51,31 +58,11 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useRouter } from "vue-router";
 
 import eyeOpen from "@/assets/icons/eye-open.png";
 import eyeClosed from "@/assets/icons/eye-closed.png";
-
-import { watch } from "vue";
-
-/* 한글 → 영문 매핑 */
-const hangulToEngMap = {
-  'ㅂ':'q','ㅈ':'w','ㄷ':'e','ㄱ':'r','ㅅ':'t',
-  'ㅛ':'y','ㅕ':'u','ㅑ':'i','ㅐ':'o','ㅔ':'p',
-  'ㅁ':'a','ㄴ':'s','ㅇ':'d','ㄹ':'f','ㅎ':'g',
-  'ㅗ':'h','ㅓ':'j','ㅏ':'k','ㅣ':'l',
-  'ㅋ':'z','ㅌ':'x','ㅊ':'c','ㅍ':'v','ㅠ':'b',
-  'ㅜ':'n','ㅡ':'m'
-};
-
-function convertHangulToEng(input) {
-  return input
-    .split("")
-    .map(ch => hangulToEngMap[ch] || ch)
-    .join("");
-}
-
 
 const router = useRouter();
 const showPw = ref(false);
@@ -85,25 +72,35 @@ const form = ref({
   password: "",
 });
 
+/* 한글 → 영문 자동 변환 */
+const hangulToEngMap = {
+  'ㅂ':'q','ㅈ':'w','ㄷ':'e','ㄱ':'r','ㅅ':'t',
+  'ㅛ':'y','ㅕ':'u','ㅑ':'i','ㅐ':'o','ㅔ':'p',
+  'ㅁ':'a','ㄴ':'s','ㅇ':'d','ㄹ':'f','ㅎ':'g',
+  'ㅗ':'h','ㅓ':'j','ㅏ':'k','ㅣ':'l',
+  'ㅋ':'z','ㅌ':'x','ㅊ':'c','ㅍ':'v','ㅠ':'b',
+  'ㅜ':'n','ㅡ':'m'
+};
+
 watch(
   () => form.value.password,
   (val) => {
-    const converted = convertHangulToEng(val || "");
-    if (converted !== val) {
-      form.value.password = converted;
-    }
+    const converted = val
+      .split("")
+      .map(ch => hangulToEngMap[ch] || ch)
+      .join("");
+    if (converted !== val) form.value.password = converted;
   }
 );
-/* 임시 유저 데이터 - 회원가입 기능 연결 전까지 사용 */
+
 const mockUsers = [
   { username: "gaemi", nickname: "개미봇", password: "1234" },
-  { username: "test", nickname: "주연", password: "1234" },
+  { username: "test", nickname: "관리자", password: "1234" },
 ];
 
-/* 로그인 */
 const onSubmit = () => {
   const user = mockUsers.find(
-    (u) =>
+    u =>
       u.username === form.value.username &&
       u.password === form.value.password
   );
@@ -113,10 +110,6 @@ const onSubmit = () => {
     return;
   }
 
-  /* --------------------------
-      로그인 상태 저장 (중요)
-      MainLayout에서 읽기 위한 구조
-  ---------------------------*/
   localStorage.setItem(
     "user",
     JSON.stringify({
@@ -126,68 +119,98 @@ const onSubmit = () => {
     })
   );
 
-  alert("로그인 성공!");
+  alert("로그인 성공!"); // ✅ 이거 다시 추가
   router.push("/app/dashboard");
 };
 
-/* 이동 함수 */
 const goSignup = () => router.push("/signup");
 const goWelcome = () => router.push("/welcome");
 </script>
 
 <style scoped>
-/* 기존 디자인 그대로 */
 .auth-page {
-  width: 100%;
   min-height: 100vh;
   background: #f7f8fa;
   display: flex;
   justify-content: center;
   align-items: center;
 }
+
 .auth-card {
-  width: 420px;
+  width: 380px;
   background: white;
   padding: 36px 40px;
   border-radius: 16px;
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.06);
 }
-.auth-card.small {
-  width: 380px;
+
+.auth-logo {
+  width: 56px;
+  margin: 0 auto 12px;
+  display: block;
 }
+
+.header {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
 .title {
   font-size: 26px;
   font-weight: 700;
-  margin-bottom: 4px;
 }
+
 .subtitle {
   font-size: 14px;
   color: #6b7280;
-  margin-bottom: 24px;
+  margin-top: 4px;
 }
+
 .form {
   display: flex;
   flex-direction: column;
   gap: 20px;
 }
+
 .field label {
   display: block;
   font-size: 13px;
   font-weight: 600;
   margin-bottom: 6px;
 }
+
 input {
   width: 100%;
   padding: 10px 14px;
   border-radius: 8px;
   border: 1px solid #d1d5db;
+  box-sizing: border-box;
 }
-.input-row {
+
+.input-wrapper {
   position: relative;
-  display: flex;
-  align-items: center;
 }
+
+.input-wrapper input {
+  padding-right: 44px;
+}
+
+.icon-btn {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.eye-icon {
+  width: 20px;
+}
+
 .primary-btn {
+  margin-top: 8px;
   width: 100%;
   background: #2563eb;
   color: white;
@@ -196,33 +219,15 @@ input {
   border: none;
   font-weight: 600;
 }
+
 .footer-text {
   margin-top: 20px;
   text-align: center;
 }
+
 .link {
   color: #2563eb;
-  cursor: pointer;
   font-weight: 600;
-}
-.icon-btn {
-  position: absolute;
-  right: 10px;
-  border: none;
-  background: none;
   cursor: pointer;
-  padding: 0;
 }
-
-.eye-icon {
-  width: 20px;
-  height: 20px;
-}
-.auth-logo {
-  width: 56px;
-  height: 56px;
-  margin: 0 auto 12px;
-  display: block;
-}
-
 </style>

--- a/gaemi-project/frontend-pjt/src/pages/SignupPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/SignupPage.vue
@@ -512,4 +512,11 @@ input {
   margin: 0 auto 12px;
   display: block;
 }
+/* 🔧 input 깨짐 방지 핵심 패치 */
+.input-row input,
+.input {
+  min-width: 0;
+  box-sizing: border-box;
+}
+
 </style>

--- a/gaemi-project/frontend-pjt/src/pages/SignupPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/SignupPage.vue
@@ -88,7 +88,7 @@
           </div>
 
           <!-- 전화번호 -->
-          <div class="field">
+          <!-- <div class="field">
             <label>전화번호</label>
             <input
               v-model="form.phone"
@@ -97,7 +97,7 @@
               @input="handlePhoneInput"
             />
             <p v-if="phoneStatus === 'invalid'" class="error-msg">❌ 전화번호는 숫자만 입력할 수 있습니다.</p>
-          </div>
+          </div> -->
 
         </div> <!-- info-grid -->
       </section>
@@ -178,7 +178,7 @@ const form = ref({
   password: "",
   passwordConfirm: "",
   email: "",
-  phone: "",
+  // phone: "",
   favorites: []
 });
 
@@ -257,12 +257,12 @@ const validateEmail = () => {
 };
 
 /* 전화번호 */
-const phoneStatus = ref(null);
-const handlePhoneInput = (e) => {
-  const onlyNumbers = e.target.value.replace(/[^0-9]/g, "");
-  phoneStatus.value = onlyNumbers !== e.target.value ? "invalid" : null;
-  form.value.phone = onlyNumbers;
-};
+// const phoneStatus = ref(null);
+// const handlePhoneInput = (e) => {
+//   const onlyNumbers = e.target.value.replace(/[^0-9]/g, "");
+//   phoneStatus.value = onlyNumbers !== e.target.value ? "invalid" : null;
+//   form.value.phone = onlyNumbers;
+// };
 
 /* 관심 종목 */
 const searchQuery = ref("");
@@ -299,8 +299,8 @@ const onSubmit = () => {
   if (emailStatus.value !== "valid")
     return alert("올바른 이메일을 입력해주세요.");
 
-  if (!form.value.phone || phoneStatus.value === "invalid")
-    return alert("전화번호는 숫자만 입력할 수 있습니다.");
+  // if (!form.value.phone || phoneStatus.value === "invalid")
+  //   return alert("전화번호는 숫자만 입력할 수 있습니다.");
 
   localStorage.setItem("user", JSON.stringify(form.value));
   alert("회원가입 완료!");

--- a/gaemi-project/frontend-pjt/src/router/index.js
+++ b/gaemi-project/frontend-pjt/src/router/index.js
@@ -1,27 +1,33 @@
 import { createRouter, createWebHistory } from "vue-router";
 
 import MainLayout from "@/components/layout/MainLayout.vue";
+import AuthLayout from "@/components/layout/AuthLayout.vue";
 
-// 단독 페이지
 import WelcomePage from "@/pages/WelcomePage.vue";
 import LoginPage from "@/pages/LoginPage.vue";
 import SignupPage from "@/pages/SignupPage.vue";
 
-// MainLayout 페이지
 import DashboardPage from "@/pages/DashboardPage.vue";
 import AiNewsPage from "@/pages/AiNewsPage.vue";
 import AlertSettingsPage from "@/pages/AlertSettingsPage.vue";
 
 const routes = [
-  { path: "/", redirect: "/welcome" },
+  // ✅ 시작 페이지
+  {
+    path: "/",
+    component: AuthLayout,
+    children: [
+      { path: "", component: WelcomePage },   // 👈 여기!
+      { path: "welcome", component: WelcomePage },
+      { path: "login", component: LoginPage },
+      { path: "signup", component: SignupPage },
+    ],
+  },
 
-  { path: "/welcome", component: WelcomePage },
-  { path: "/login", component: LoginPage },
-  { path: "/signup", component: SignupPage },
-
+  // ✅ 로그인 이후 앱
   {
     path: "/app",
-    component: MainLayout, // 여기서만 상단바 렌더링됨
+    component: MainLayout,
     children: [
       { path: "dashboard", component: DashboardPage },
       { path: "ai-news", component: AiNewsPage },
@@ -30,9 +36,7 @@ const routes = [
   },
 ];
 
-const router = createRouter({
+export default createRouter({
   history: createWebHistory(),
   routes,
 });
-
-export default router;

--- a/gaemi-project/frontend-pjt/src/router/index.js
+++ b/gaemi-project/frontend-pjt/src/router/index.js
@@ -10,6 +10,7 @@ import SignupPage from "@/pages/SignupPage.vue";
 import DashboardPage from "@/pages/DashboardPage.vue";
 import AiNewsPage from "@/pages/AiNewsPage.vue";
 import AlertSettingsPage from "@/pages/AlertSettingsPage.vue";
+import ChatbotPage from "@/pages/ChatbotPage.vue";
 
 const routes = [
   // ✅ 시작 페이지
@@ -32,6 +33,7 @@ const routes = [
       { path: "dashboard", component: DashboardPage },
       { path: "ai-news", component: AiNewsPage },
       { path: "alerts", component: AlertSettingsPage },
+      { path: "/app/chatbot", component: ChatbotPage, },
     ],
   },
 ];

--- a/gaemi-project/frontend-pjt/src/stores/alertEventsStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/alertEventsStore.js
@@ -1,0 +1,101 @@
+// src/stores/alertEventsStore.js
+import { defineStore } from "pinia";
+import { ref, computed } from "vue";
+import { useToastStore } from "@/stores/toastStore";
+
+export const useAlertEventsStore = defineStore("alertEvents", () => {
+  /* ------------------------
+     State
+  ------------------------ */
+  const events = ref([]);
+
+  /* ------------------------
+     Getters
+  ------------------------ */
+  const latestEvents = computed(() =>
+    [...events.value].sort(
+      (a, b) => new Date(b.triggeredAt) - new Date(a.triggeredAt)
+    )
+  );
+
+  const count = computed(() => events.value.length);
+
+  /* ------------------------
+     LocalStorage (선택)
+  ------------------------ */
+  function saveToLocal() {
+    localStorage.setItem("alert_events", JSON.stringify(events.value));
+  }
+
+  function loadFromLocal() {
+    const saved = localStorage.getItem("alert_events");
+    if (!saved) return;
+
+    try {
+      const parsed = JSON.parse(saved);
+      if (Array.isArray(parsed)) events.value = parsed;
+    } catch (e) {
+      // 파싱 실패 시 무시
+    }
+  }
+
+  // ⭐ 새로고침 유지
+  loadFromLocal();
+
+  /* ------------------------
+     Actions
+  ------------------------ */
+  function addEvent(event) {
+    /*
+      event 구조 예시 (Flink / WebSocket 기준)
+      {
+        stockCode,
+        stockName,
+        condition,
+        target,
+        currentPrice,
+        triggeredAt
+      }
+    */
+
+    const alertEvent = {
+      id: Date.now(),
+      stockCode: event.stockCode,
+      stockName: event.stockName,
+      condition: event.condition,
+      target: event.target,
+      currentPrice: event.currentPrice,
+      triggeredAt: event.triggeredAt || new Date().toISOString(),
+    };
+
+    // 1️⃣ 이벤트 저장
+    events.value.push(alertEvent);
+    saveToLocal();
+
+    // 2️⃣ 토스트 발생 (🔥 여기서만)
+    const toastStore = useToastStore();
+    toastStore.push({
+      type: "info",
+      title: "알림 도착",
+      message: `${alertEvent.stockName} ${alertEvent.target}원 조건 충족`,
+    });
+  }
+
+  function clearEvents() {
+    events.value = [];
+    saveToLocal();
+  }
+
+  return {
+    // state
+    events,
+
+    // getters
+    latestEvents,
+    count,
+
+    // actions
+    addEvent,
+    clearEvents,
+  };
+});

--- a/gaemi-project/frontend-pjt/src/stores/alertEventsStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/alertEventsStore.js
@@ -1,7 +1,6 @@
 // src/stores/alertEventsStore.js
 import { defineStore } from "pinia";
 import { ref, computed } from "vue";
-import { useToastStore } from "@/stores/toastStore";
 
 export const useAlertEventsStore = defineStore("alertEvents", () => {
   /* ------------------------
@@ -33,7 +32,11 @@ export const useAlertEventsStore = defineStore("alertEvents", () => {
 
     try {
       const parsed = JSON.parse(saved);
-      if (Array.isArray(parsed)) events.value = parsed;
+      if (Array.isArray(parsed)) {
+        events.value = parsed;
+        cleanupOldEvents();
+        saveToLocal();
+      }
     } catch (e) {
       // 파싱 실패 시 무시
     }
@@ -41,6 +44,19 @@ export const useAlertEventsStore = defineStore("alertEvents", () => {
 
   // ⭐ 새로고침 유지
   loadFromLocal();
+
+  const RETENTION_DAYS = 7;
+
+  function cleanupOldEvents() {
+    const now = new Date();
+    const cutoff = new Date(
+      now.getTime() - RETENTION_DAYS * 24 * 60 * 60 * 1000
+    );
+
+    events.value = events.value.filter(ev => {
+      return new Date(ev.triggeredAt) >= cutoff;
+    });
+  }
 
   /* ------------------------
      Actions
@@ -70,15 +86,8 @@ export const useAlertEventsStore = defineStore("alertEvents", () => {
 
     // 1️⃣ 이벤트 저장
     events.value.push(alertEvent);
+    cleanupOldEvents();
     saveToLocal();
-
-    // 2️⃣ 토스트 발생 (🔥 여기서만)
-    const toastStore = useToastStore();
-    toastStore.push({
-      type: "info",
-      title: "알림 도착",
-      message: `${alertEvent.stockName} ${alertEvent.target}원 조건 충족`,
-    });
   }
 
   function clearEvents() {

--- a/gaemi-project/frontend-pjt/src/stores/alertsStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/alertsStore.js
@@ -1,34 +1,22 @@
 // src/stores/alertsStore.js
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { ref, computed } from "vue";
 
 const CONDITION_META = {
-  gte: {
-    label: "가격 이상",
-    unit: "원",
-  },
-  lte: {
-    label: "가격 이하",
-    unit: "원",
-  },
-  changeUp: {
-    label: "전일 대비 상승률 이상",
-    unit: "%",
-  },
-  changeDown: {
-    label: "전일 대비 하락률 이하",
-    unit: "%",
-  },
+  gte: { label: "가격 이상", unit: "원" },
+  lte: { label: "가격 이하", unit: "원" },
+  changeUp: { label: "전일 대비 상승률 이상", unit: "%" },
+  changeDown: { label: "전일 대비 하락률 이하", unit: "%" },
 };
 
 function makeDescription(condition, target) {
   const meta = CONDITION_META[condition];
   if (!meta) return "";
-
   return `${meta.label}: ${target}${meta.unit}`;
 }
 
 export const useAlertsStore = defineStore("alerts", () => {
+  // ✅ 알림 "조건" 원본
   const alerts = ref([]);
 
   /* ------------------------
@@ -41,9 +29,37 @@ export const useAlertsStore = defineStore("alerts", () => {
   function loadFromLocal() {
     const saved = localStorage.getItem("alerts");
     if (saved) {
-      alerts.value = JSON.parse(saved);
+      try {
+        const parsed = JSON.parse(saved);
+        if (Array.isArray(parsed)) alerts.value = parsed;
+      } catch (e) {
+        // 파싱 실패 시 무시
+      }
     }
   }
+
+  // ✅ 초기 로드 시 LocalStorage에서 데이터 불러오기
+  loadFromLocal();
+
+  /* ------------------------
+     대시보드용 "알림 내역" 형태로 변환
+  ------------------------ */
+  const alertEvents = computed(() =>
+    alerts.value
+      .filter((a) => a.enabled !== false) // enabled true만 노출
+      .slice() // 원본 보호
+      .reverse() // 최신이 위로
+      .map((a) => ({
+        id: a.id,
+        stockName: a.stockName,
+        title: a.description || makeDescription(a.condition, a.target),
+        time: "설정됨",
+        statusClass: "working",
+        stockCode: a.stockCode,
+        condition: a.condition,
+        target: a.target,
+      }))
+  );
 
   /* ------------------------
      CRUD
@@ -58,41 +74,44 @@ export const useAlertsStore = defineStore("alerts", () => {
       description: makeDescription(condition, target),
       enabled: true,
     });
-    saveToLocal();
+    saveToLocal(); // 새로 추가된 알림은 로컬스토리지에 즉시 저장
   }
 
   function removeAlert(id) {
-    alerts.value = alerts.value.filter(a => a.id !== id);
-    saveToLocal();
+    alerts.value = alerts.value.filter((a) => a.id !== id);
+    saveToLocal(); // 알림 삭제 후 로컬스토리지 업데이트
   }
 
   function toggleAlert(id) {
-    const alert = alerts.value.find(a => a.id === id);
+    const alert = alerts.value.find((a) => a.id === id);
     if (!alert) return;
-
     alert.enabled = !alert.enabled;
-    saveToLocal();
+    saveToLocal(); // 알림 상태 변경 후 로컬스토리지 업데이트
   }
 
   /* ------------------------
      관심 종목 연동
   ------------------------ */
   function hasAlertsForStock(stockCode) {
-    return alerts.value.some(a => a.stockCode === stockCode);
+    return alerts.value.some((a) => a.stockCode === stockCode);
   }
 
   function removeByStockCode(stockCode) {
-    alerts.value = alerts.value.filter(a => a.stockCode !== stockCode);
-    saveToLocal();
+    alerts.value = alerts.value.filter((a) => a.stockCode !== stockCode);
+    saveToLocal(); // 관심 종목 삭제 후 로컬스토리지 업데이트
   }
 
   return {
     alerts,
+    alertEvents, // 대시보드에서 쓰는 값
+
     addAlert,
     removeAlert,
     toggleAlert,
     hasAlertsForStock,
     removeByStockCode,
+
     loadFromLocal,
+    saveToLocal,
   };
 });

--- a/gaemi-project/frontend-pjt/src/stores/chatbotStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/chatbotStore.js
@@ -1,10 +1,15 @@
 // src/stores/chatbotStore.js
 import { defineStore } from "pinia";
 
+const STORAGE_KEYS = {
+  OPEN: "chatbot_open",
+  MESSAGES: "chatbot_messages",
+};
+
 export const useChatbotStore = defineStore("chatbot", {
   state: () => ({
     // 우측 하단 패널 열림/닫힘
-    isOpen: false,
+    isOpen: localStorage.getItem(STORAGE_KEYS.OPEN) === 'true',
 
     // ✅ 우측 하단 챗봇 + ChatbotPage가 "같이" 쓰는 대화 기록
     // role: "user" | "assistant" | "system"
@@ -28,9 +33,20 @@ export const useChatbotStore = defineStore("chatbot", {
     /* -----------------------
        Panel/Page 공통 제어
     ------------------------ */
+    init() {
+      this.loadFromLocal();
+
+      // 챗봇이 열려있던 상태 + 메시지 없음 → 안내 메시지 복원
+      if (this.isOpen && this.messages.length === 0) {
+        this.addSystemMessage(
+          "안녕하세요 👋\n관심 종목, 실적, 뉴스 요약 등 무엇이든 물어보세요."
+        );
+      }
+    },
+
     open() {
       this.isOpen = true;
-
+      localStorage.setItem(STORAGE_KEYS.OPEN, "true");
       // ✅ 처음 열릴 때만 안내 메시지 추가
       if (this.messages.length === 0) {
         this.addSystemMessage(
@@ -40,9 +56,11 @@ export const useChatbotStore = defineStore("chatbot", {
     },
     close() {
       this.isOpen = false;
+      localStorage.setItem(STORAGE_KEYS.OPEN, "false");
     },
+
     toggle() {
-      this.isOpen = !this.isOpen;
+      this.isOpen ? this.close() : this.open();
     },
 
     /* -----------------------
@@ -60,6 +78,9 @@ export const useChatbotStore = defineStore("chatbot", {
         createdAt: new Date().toISOString(),
         ...meta,
       });
+
+      // 메시지 추가될 때마다 저장
+      this.saveToLocal();
     },
 
     addUserMessage(text, meta) {
@@ -87,19 +108,20 @@ export const useChatbotStore = defineStore("chatbot", {
     ------------------------ */
     loadFromLocal() {
       try {
-        const raw = localStorage.getItem("chatbot_messages");
+        const raw = localStorage.getItem(STORAGE_KEYS.MESSAGES);
         if (!raw) return;
+
         const parsed = JSON.parse(raw);
         if (Array.isArray(parsed)) this.messages = parsed;
-      } catch (e) {
+      } catch {
         // 파싱 실패 시 무시
       }
     },
 
     saveToLocal() {
       try {
-        localStorage.setItem("chatbot_messages", JSON.stringify(this.messages));
-      } catch (e) {
+        localStorage.setItem(STORAGE_KEYS.MESSAGES, JSON.stringify(this.messages));
+      } catch {
         // 저장 실패 시 무시
       }
     },
@@ -127,10 +149,7 @@ export const useChatbotStore = defineStore("chatbot", {
         // 임시 mock 응답
         await new Promise((r) => setTimeout(r, 250));
         this.addAssistantMessage(`(임시응답) "${userText}"에 대한 답변입니다.`);
-
-        // 저장(원하면)
-        this.saveToLocal();
-      } catch (e) {
+      } catch {
         this.lastError = "챗봇 응답에 실패했습니다.";
       } finally {
         this.isLoading = false;

--- a/gaemi-project/frontend-pjt/src/stores/chatbotStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/chatbotStore.js
@@ -1,69 +1,140 @@
+// src/stores/chatbotStore.js
 import { defineStore } from "pinia";
 
-/**
- * 🤖 AI Chatbot Store
- * - 챗봇 전역 상태 관리
- * - UI / 애니메이션 / 위치는 관여하지 않음
- * - 현재는 mock 기반, 추후 API 연동 예정
- */
 export const useChatbotStore = defineStore("chatbot", {
   state: () => ({
-    /** 챗봇 패널 열림 여부 */
+    // 우측 하단 패널 열림/닫힘
     isOpen: false,
 
-    /** 챗봇 메시지 목록 */
+    // ✅ 우측 하단 챗봇 + ChatbotPage가 "같이" 쓰는 대화 기록
+    // role: "user" | "assistant" | "system"
+    // content: string
     messages: [],
+
+    // 입력/응답 진행 상태 (UI에서 스피너 등)
+    isLoading: false,
+
+    // 필요하면 에러 표시
+    lastError: null,
   }),
 
+  getters: {
+    hasMessages: (state) => state.messages.length > 0,
+    lastMessage: (state) =>
+      state.messages.length ? state.messages[state.messages.length - 1] : null,
+  },
+
   actions: {
-    /** 챗봇 열기 */
-    openChat() {
+    /* -----------------------
+       Panel/Page 공통 제어
+    ------------------------ */
+    open() {
       this.isOpen = true;
 
-      // ⭐ 처음 열릴 때만 초기 메시지 세팅
+      // ✅ 처음 열릴 때만 안내 메시지 추가
       if (this.messages.length === 0) {
-        this.messages.push({
-          role: "bot",
-          content:
-            '안녕하세요! "gAemI" AI 어시스턴트입니다.\n실시간 주가 데이터와 AI 뉴스 분석을 결합한 RAG 시스템으로 응답합니다.',
-        });
+        this.addSystemMessage(
+          "안녕하세요 👋\n관심 종목, 실적, 뉴스 요약 등 무엇이든 물어보세요."
+        );
       }
     },
-
-
-    /** 챗봇 닫기 */
-    closeChat() {
+    close() {
       this.isOpen = false;
     },
-
-    /** 챗봇 열림/닫힘 토글 */
-    toggleChat() {
+    toggle() {
       this.isOpen = !this.isOpen;
     },
 
-    /**
-     * 메시지 전송 (mock)
-     * @param {string} text - 사용자 입력 메시지
-     */
-    sendMessageMock(text) {
-      if (!text || !text.trim()) return;
+    /* -----------------------
+       메시지 조작 (공통)
+    ------------------------ */
+    addMessage(role, content, meta = {}) {
+      // content가 비어있으면 추가하지 않음(실수 방지)
+      const text = (content ?? "").toString();
+      if (!text.trim()) return;
 
-      // 사용자 메시지
       this.messages.push({
-        role: "user",
+        id: `${Date.now()}_${Math.random().toString(16).slice(2)}`,
+        role,
         content: text,
-      });
-
-      // mock AI 응답
-      this.messages.push({
-        role: "bot",
-        content: "여기에 백엔드에서 받은 RAG 응답 내용을 표시합니다.",
+        createdAt: new Date().toISOString(),
+        ...meta,
       });
     },
 
-    /** 대화 초기화 (선택) */
+    addUserMessage(text, meta) {
+      this.addMessage("user", text, meta);
+    },
+
+    addAssistantMessage(text, meta) {
+      this.addMessage("assistant", text, meta);
+    },
+
+    addSystemMessage(text, meta) {
+      this.addMessage("system", text, meta);
+    },
+
     clearMessages() {
       this.messages = [];
+      this.lastError = null;
+      this.isLoading = false;
+    },
+
+    /* -----------------------
+       (선택) 로컬스토리지 영속화
+       - 새로고침해도 대화 유지하고 싶으면 사용
+       - 원치 않으면 이 블록 통째로 안 써도 됨
+    ------------------------ */
+    loadFromLocal() {
+      try {
+        const raw = localStorage.getItem("chatbot_messages");
+        if (!raw) return;
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed)) this.messages = parsed;
+      } catch (e) {
+        // 파싱 실패 시 무시
+      }
+    },
+
+    saveToLocal() {
+      try {
+        localStorage.setItem("chatbot_messages", JSON.stringify(this.messages));
+      } catch (e) {
+        // 저장 실패 시 무시
+      }
+    },
+
+    /* -----------------------
+       (선택) 통합 send 액션
+       - 지금은 mock 응답으로 둠
+       - 나중에 API 붙일 때 여기만 교체하면 됨
+    ------------------------ */
+    async send(text) {
+      const userText = (text ?? "").toString().trim();
+      if (!userText) return;
+
+      this.lastError = null;
+      this.isLoading = true;
+
+      // 1) 사용자 메시지 기록
+      this.addUserMessage(userText);
+
+      try {
+        // ✅ TODO: 실제 백엔드/LLM API 호출로 교체
+        // const res = await api.post("/chat", { message: userText });
+        // this.addAssistantMessage(res.data.answer);
+
+        // 임시 mock 응답
+        await new Promise((r) => setTimeout(r, 250));
+        this.addAssistantMessage(`(임시응답) "${userText}"에 대한 답변입니다.`);
+
+        // 저장(원하면)
+        this.saveToLocal();
+      } catch (e) {
+        this.lastError = "챗봇 응답에 실패했습니다.";
+      } finally {
+        this.isLoading = false;
+      }
     },
   },
 });

--- a/gaemi-project/frontend-pjt/src/stores/chatbotStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/chatbotStore.js
@@ -1,0 +1,69 @@
+import { defineStore } from "pinia";
+
+/**
+ * 🤖 AI Chatbot Store
+ * - 챗봇 전역 상태 관리
+ * - UI / 애니메이션 / 위치는 관여하지 않음
+ * - 현재는 mock 기반, 추후 API 연동 예정
+ */
+export const useChatbotStore = defineStore("chatbot", {
+  state: () => ({
+    /** 챗봇 패널 열림 여부 */
+    isOpen: false,
+
+    /** 챗봇 메시지 목록 */
+    messages: [],
+  }),
+
+  actions: {
+    /** 챗봇 열기 */
+    openChat() {
+      this.isOpen = true;
+
+      // ⭐ 처음 열릴 때만 초기 메시지 세팅
+      if (this.messages.length === 0) {
+        this.messages.push({
+          role: "bot",
+          content:
+            '안녕하세요! "gAemI" AI 어시스턴트입니다.\n실시간 주가 데이터와 AI 뉴스 분석을 결합한 RAG 시스템으로 응답합니다.',
+        });
+      }
+    },
+
+
+    /** 챗봇 닫기 */
+    closeChat() {
+      this.isOpen = false;
+    },
+
+    /** 챗봇 열림/닫힘 토글 */
+    toggleChat() {
+      this.isOpen = !this.isOpen;
+    },
+
+    /**
+     * 메시지 전송 (mock)
+     * @param {string} text - 사용자 입력 메시지
+     */
+    sendMessageMock(text) {
+      if (!text || !text.trim()) return;
+
+      // 사용자 메시지
+      this.messages.push({
+        role: "user",
+        content: text,
+      });
+
+      // mock AI 응답
+      this.messages.push({
+        role: "bot",
+        content: "여기에 백엔드에서 받은 RAG 응답 내용을 표시합니다.",
+      });
+    },
+
+    /** 대화 초기화 (선택) */
+    clearMessages() {
+      this.messages = [];
+    },
+  },
+});

--- a/gaemi-project/frontend-pjt/src/stores/marketStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/marketStore.js
@@ -1,0 +1,58 @@
+// src/stores/marketStore.js
+import { defineStore } from "pinia";
+
+export const useMarketStore = defineStore("market", {
+  state: () => ({
+    // 시장 지수 요약
+    kospi: {
+      price: 2645.85,
+      diff: 15.32,
+      rate: 0.58,
+    },
+    kosdaq: {
+      price: 745.12,
+      diff: -3.45,
+      rate: -0.46,
+    },
+
+    isLoading: false,
+    lastUpdatedAt: null,
+  }),
+
+  getters: {
+    isKospiUp: (state) => state.kospi.diff >= 0,
+    isKosdaqUp: (state) => state.kosdaq.diff >= 0,
+  },
+
+  actions: {
+    /* ---------------------------------
+       🔹 더미 로딩 (현재 사용)
+    --------------------------------- */
+    loadMock() {
+      this.lastUpdatedAt = new Date().toISOString();
+    },
+
+    /* ---------------------------------
+       🔹 나중에 API 붙일 자리
+       예: GET /api/market/summary
+    --------------------------------- */
+    async fetchMarketSummary() {
+      this.isLoading = true;
+
+      try {
+        // TODO: 실제 API 연결
+        // const res = await api.get("/market/summary");
+        // this.kospi = res.data.kospi;
+        // this.kosdaq = res.data.kosdaq;
+
+        // 임시 mock (지금은 안 씀)
+        await new Promise((r) => setTimeout(r, 300));
+        this.lastUpdatedAt = new Date().toISOString();
+      } catch (e) {
+        console.error("시장 지수 조회 실패", e);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+  },
+});

--- a/gaemi-project/frontend-pjt/src/stores/toastStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/toastStore.js
@@ -1,0 +1,28 @@
+import { defineStore } from "pinia";
+
+let id = 0;
+
+export const useToastStore = defineStore("toast", {
+  state: () => ({
+    toasts: [],
+    max: 5, // ⭐ 최대 5개
+  }),
+
+  actions: {
+    push(toast) {
+      this.toasts.push({
+        id: id++,
+        ...toast,
+      });
+
+      // ⭐ FIFO: 5개 초과 시 앞에서 제거
+      if (this.toasts.length > this.max) {
+        this.toasts.shift();
+      }
+    },
+
+    remove(toastId) {
+      this.toasts = this.toasts.filter((t) => t.id !== toastId);
+    },
+  },
+});


### PR DESCRIPTION
## 📌 개요
로그인 이후 전역에서 사용되는 **AI 챗봇 플로팅 UI와 알림 토스트 UI 구조를 선행 구현**했습니다.
본 PR은 실제 AI 응답 및 알림 트리거 API 연동 이전 단계로, **UI/상태 구조를 안정적으로 확정**하는 데 목적이 있습니다.

또한 일정 이슈로 AI 뉴스 분석 기능을 본 버전에서는 제외하고, **AI 챗봇 중심 UX로 재구성**했습니다.
(AI 뉴스 분석 기능은 업데이트 버전으로 구현할 예정입니다.)

## ✨ 주요 변경 사항
- [x] 로그인 이후 전역에서 노출되는 **AI 챗봇 플로팅 버튼(ChatbotFab)** 구현
- [x] 챗봇 버튼 클릭 시 열리는 **전역 챗봇 패널(ChatbotPanel)** 구현
- [x] AI 챗봇 전용 페이지(ChatbotPage) 신규 생성
- [x] 알림 토스트 전역 UI 및 스택 구조 구현 (최대 5개, FIFO)
- [x] 알림 이벤트 관리용 `alertEventsStore` 선행 설계 (Pre-API)
- [x] 상단 종(🔔) 버튼 기반 알림 드롭다운 UI 구조 구현
- [x] 기존 AI 뉴스 분석 페이지 노출 제거 (추후 업데이트 예정)

## 🔍 관련 이슈
- [I-37](https://github.com/gAemI-AI/gAemI-AI/issues/37)

## 🙏 To Reviewers
- 본 PR은 **API 연동 이전 단계의 UI/상태 구조 확정**을 목표로 합니다.
- 알림/챗봇 관련 store 구조는 추후 WebSocket 및 Chat API 연동을 고려해 설계되었습니다.
- AI 뉴스 분석 기능은 일정상 제외되었으며, 다음 버전에서 재도입 예정입니다.

### 🔔 알림 토스트 관련 안내 (중요)
- 현재 알림 토스트는 **실제 알림 이벤트가 존재할 때만 표시되는 구조**입니다.
- 본 PR은 API / WebSocket 연동 이전 단계이므로,  
  **서버에서 알림 이벤트를 내려주거나 자동으로 생성하는 로직은 포함되어 있지 않습니다.**
- 따라서 새로 클론한 환경에서 `test / 1234` 등으로 로그인할 경우,
  브라우저 localStorage에 알림 이벤트가 없어 **알림 토스트가 표시되지 않는 것이 정상 동작**입니다.
- 알림 토스트 UI 자체의 동작(스택, 최대 5개, 전역 유지)은  
  **알림 이벤트가 주입되는 경우 정상적으로 동작하도록 구현되어 있습니다.**
- 추후 Notification API / WebSocket 연동 시,
  로그인 전 발생한 알림을 포함해 실제 이벤트가 전달되면 토스트가 표시될 예정입니다.

## 🧪 테스트 방법
1. *http://localhost:5173/* 접속
2. 로그인 (test, 1234) 후:
    - 우측 하단 챗봇 플로팅 버튼 노출 확인
    - 챗봇 버튼 클릭 시 패널 오픈 확인
    - Dashboard / Chatbot / Alert 관리 페이지 이동 시 UI 유지 확인