### PR TITLE
[I-43] WebSocket 기반 실시간 알림 및 차트 데이터 파이프라인 구축

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Flink 알림 시스템: 이상(Broadcast)과 현실의 간극 좁히기](https://www.notion.so/Flink-Broadcast-2cc0c3d3c9ea80cca4efdd88189fbc67?source=copy_link)
 - [주식 캔들 차트: 시간 축의 불연속성을 선택한 기술적 배경](https://www.notion.so/2cd0c3d3c9ea807bbe58de48840eba98?source=copy_link)
 - [Kafka → Elasticsearch Index Consumer 설계 및 구현 배경](https://www.notion.so/Kafka-Elasticsearch-Index-Consumer-2cf0c3d3c9ea8068a0ede8a2d90a6a6c?source=copy_link)
+- [WebSocket 기반 실시간 시세 및 알림 파이프라인](https://www.notion.so/WebSocket-2cf0c3d3c9ea8016b0b9f67bd3709bf2?source=copy_link)
 
 ## 📌 Git 협업 전략
 -

--- a/gaemi-project/backend-pjt/gaemi_backend/asgi.py
+++ b/gaemi-project/backend-pjt/gaemi_backend/asgi.py
@@ -8,9 +8,24 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 """
 
 import os
-
+import django
 from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'gaemi_backend.settings')
+django.setup()
 
-application = get_asgi_application()
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.auth import AuthMiddlewareStack
+from channels.security.websocket import AllowedHostsOriginValidator
+import gaemi_backend.routing
+
+application = ProtocolTypeRouter({
+    "http": get_asgi_application(),
+    "websocket": AllowedHostsOriginValidator(  # Origin 검사
+        AuthMiddlewareStack(
+            URLRouter(
+                gaemi_backend.routing.websocket_urlpatterns
+            )
+        )
+    ),
+})

--- a/gaemi-project/backend-pjt/gaemi_backend/routing.py
+++ b/gaemi-project/backend-pjt/gaemi_backend/routing.py
@@ -1,0 +1,7 @@
+from django.urls import re_path
+from notifications.consumers import NotificationConsumer, ChartConsumer
+
+websocket_urlpatterns = [
+    re_path(r'ws/notifications/(?P<user_id>\w+)/$', NotificationConsumer.as_asgi()),
+    re_path(r'ws/stocks/(?P<stock_code>\w+)/$', ChartConsumer.as_asgi()),
+]

--- a/gaemi-project/backend-pjt/gaemi_backend/settings.py
+++ b/gaemi-project/backend-pjt/gaemi_backend/settings.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = [
 # Application definition
 
 INSTALLED_APPS = [
+    'daphne',  # django.contrib.staticfiles보다 위에 있어야 함!
     'rest_framework', # Django REST framework
     'corsheaders',  # CORS headers (프론트와 통합을 고려할 때 추가)
     'rest_framework.authtoken',
@@ -48,6 +49,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'channels',  # Django Channels
     # 'django_elasticsearch_dsl', # ORM과 연동할 때 필요
 
     # My apps
@@ -88,6 +90,18 @@ TEMPLATES = [
         },
     },
 ]
+
+ASGI_APPLICATION = 'gaemi_backend.asgi.application'
+
+# Channel Layer 설정 (Redis 사용)
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {
+            "hosts": [("redis", 6379)],  # docker-compose 서비스명 'redis' 사용
+        },
+    },
+}
 
 WSGI_APPLICATION = 'gaemi_backend.wsgi.application'
 

--- a/gaemi-project/backend-pjt/notifications/consumers.py
+++ b/gaemi-project/backend-pjt/notifications/consumers.py
@@ -1,0 +1,61 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+class NotificationConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        # URL에서 user_id 추출 (/ws/notifications/<user_id>/)
+        self.user_id = self.scope['url_route']['kwargs']['user_id']
+        self.group_name = f"user_{self.user_id}"
+
+        # 그룹 가입
+        await self.channel_layer.group_add(
+            self.group_name,
+            self.channel_name
+        )
+        
+        await self.accept()
+        # 👇 연결 성공 로그 (이게 떠야 WebSocket 연결된 것임)
+        print(f"🔌 [WebSocket Connected] User: {self.user_id} (Channel: {self.channel_name})")
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(
+            self.group_name,
+            self.channel_name
+        )
+        print(f"🔌 [WebSocket Disconnected] User: {self.user_id}")
+
+    # Kafka Bridge에서 보낸 메시지 받기
+    async def send_alert(self, event):
+        message = event['message']
+        
+        # 클라이언트로 전송
+        await self.send(text_data=json.dumps({
+            'type': 'alert',
+            'data': message
+        }))
+        print(f"🚀 [Sent to Client] {message}")
+
+class ChartConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.stock_code = self.scope['url_route']['kwargs']['stock_code']
+        self.group_name = f"stock_{self.stock_code}"
+
+        await self.channel_layer.group_add(
+            self.group_name,
+            self.channel_name
+        )
+        await self.accept()
+        print(f"📈 [Chart WS Connected] Stock: {self.stock_code}")
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(
+            self.group_name,
+            self.channel_name
+        )
+
+    async def send_chart_data(self, event):
+        data = event['data']
+        await self.send(text_data=json.dumps({
+            'type': 'chart_update',
+            'data': data
+        }))

--- a/gaemi-project/backend-pjt/notifications/management/commands/run_kafka_bridge.py
+++ b/gaemi-project/backend-pjt/notifications/management/commands/run_kafka_bridge.py
@@ -1,0 +1,95 @@
+import json
+import asyncio
+from django.core.management.base import BaseCommand
+from channels.layers import get_channel_layer
+from kafka import KafkaConsumer
+
+class Command(BaseCommand):
+    help = 'Consume Kafka messages and push to WebSocket groups'
+
+    def handle(self, *args, **options):
+        # 파이썬 출력 버퍼링 비활성화 (로그 즉시 출력)
+        import sys
+        sys.stdout.reconfigure(line_buffering=True)
+        
+        self.stdout.write(self.style.SUCCESS('🚀 Kafka-WebSocket Bridge Started...'))
+        
+        loop = asyncio.get_event_loop()
+        try:
+            loop.run_until_complete(self.consume_loop())
+        except KeyboardInterrupt:
+            self.stdout.write(self.style.WARNING('🛑 Bridge Stopped.'))
+
+    async def consume_loop(self):
+        channel_layer = get_channel_layer()
+
+        # [MVP 배포용 설정]
+        # 1. group_id 고정: 서버 재시작 시 중복 수신 방지
+        # 2. auto_offset_reset='latest': 과거 데이터 폭주 방지 (실시간만 처리)
+        consumer = KafkaConsumer(
+            'alert', 'stock-ticks',
+            bootstrap_servers=['kafka:29092'],
+            group_id='websocket-bridge-group',  # 고정된 그룹 ID
+            auto_offset_reset='latest',         # 최신 데이터만 수신
+            enable_auto_commit=True
+        )
+
+        self.stdout.write(self.style.SUCCESS('✅ Listening to Kafka topics: alert, stock-ticks'))
+
+        for message in consumer:
+            try:
+                raw_value = message.value
+                if not raw_value:
+                    continue
+                
+                # JSON 디코딩
+                decoded_str = raw_value.decode('utf-8')
+                data = json.loads(decoded_str)
+                
+                topic = message.topic
+
+                # [Case A] 알림 메시지 (NotificationProcessor.py와 키 일치)
+                if topic == 'alert':
+                    user_id = data.get('user_id')
+                    alert_msg = data.get('message')
+                    
+                    if user_id:
+                        group_name = f"user_{user_id}"
+                        await channel_layer.group_send(
+                            group_name,
+                            {'type': 'send_alert', 'message': alert_msg}
+                        )
+                        # 로그: 너무 많으면 주석 처리
+                        print(f"📢 [Alert Push] User {user_id}: {alert_msg}")
+
+                # [Case B] 실시간 주식 데이터 (StockProducer.py와 일치)
+                elif topic == 'stock-ticks':
+                    # Producer 키: 'stock_code', 'current_price', 'rate'
+                    stock_code = data.get('stock_code')  
+                    current_price = data.get('current_price') 
+                    rate = data.get('rate')
+                    
+                    if stock_code:
+                        group_name = f"stock_{stock_code}"
+                        
+                        # 프론트엔드에 보낼 데이터 포맷팅
+                        payload = {
+                            "code": stock_code,
+                            "price": current_price,
+                            "rate": rate,
+                            "timestamp": data.get('timestamp')
+                        }
+
+                        await channel_layer.group_send(
+                            group_name,
+                            {
+                                'type': 'send_chart_data',
+                                'data': payload
+                            }
+                        )
+                        # print(f"📈 [Stock Push] {stock_code}: {current_price}")
+
+            except json.JSONDecodeError:
+                pass 
+            except Exception as e:
+                print(f"❌ Bridge Error: {e}")

--- a/gaemi-project/backend-pjt/requirements.txt
+++ b/gaemi-project/backend-pjt/requirements.txt
@@ -14,3 +14,9 @@ openai               # GPT 호출용
 elasticsearch
 
 drf-yasg
+
+# WebSocket & Redis 관련
+daphne>=4.0.0          # ASGI 서버
+channels>=4.0.0        # Django Channels
+channels-redis>=4.0.0  # Redis Channel Layer
+kafka-python>=2.0.2    # Kafka 연동

--- a/gaemi-project/docker-compose.yml
+++ b/gaemi-project/docker-compose.yml
@@ -38,11 +38,14 @@ services:
       - POSTGRES_USER=gaemi
       - POSTGRES_PASSWORD=gaemigaemi11
       - POSTGRES_HOST=db
+      - REDIS_HOST=redis  # 추가
     env_file:
       - ./backend-pjt/.env
     depends_on:
       db:
         condition: service_healthy # DB 켜짐 + 접속 가능 상태까지 대기 후 실행
+      redis:
+        condition: service_healthy
   
   # 3. 프론트엔드 서비스
   frontend:
@@ -290,6 +293,42 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_started
+    restart: on-failure
+
+  # 15. Redis (Django Channels Layer용)
+  redis:
+    image: redis:7-alpine
+    container_name: gaemi_redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # 16. Kafka-WebSocket Bridge Worker (Kafka에서 메시지를 받아서 WebSocket 그룹으로 쏘아주는 역할)
+  backend-worker:
+    build:
+      context: ./backend-pjt
+    container_name: gaemi_backend_worker
+    volumes:
+      - ./backend-pjt:/app
+    environment:
+      - PYTHONUNBUFFERED=1  
+      - POSTGRES_DB=gaemi_ai
+      - POSTGRES_USER=gaemi
+      - POSTGRES_PASSWORD=gaemigaemi11
+      - POSTGRES_HOST=db
+      - REDIS_HOST=redis
+    env_file:
+      - ./backend-pjt/.env
+    # 커스텀 커맨드 실행
+    command: python manage.py run_kafka_bridge
+    depends_on:
+      - backend
+      - kafka
+      - redis
     restart: on-failure
 
 # 볼륨 정의: 컨테이너가 꺼져도 사라지지 않는 외장하드


### PR DESCRIPTION
## 📌 개요 (Overview)
실시간성이 중요한 **주식 시세(Stock Ticks)** 와 **사용자 알림(Notifications)** 기능을 위해 WebSocket 인프라를 구축했습니다.
Kafka로 유입되는 대용량 데이터를 Django Worker가 소비(Consume)하여 Redis를 통해 클라이언트(Frontend)로 즉시 푸시(Push)하는 구조입니다.

## 🛠 주요 변경 사항
- **[Infra] Redis & Daphne 도입:** Django Channels 구동을 위한 ASGI 서버 및 Redis 레이어 추가 (`docker-compose.yml`, `settings.py`)
- **[Backend] WebSocket Consumers:** - `NotificationConsumer`: 개인화된 알림 채널 (`/ws/notifications/<user_id>/`)
  - `ChartConsumer`: 종목별 실시간 시세 채널 (`/ws/stocks/<code >/`)
- **[Worker] Kafka-WebSocket Bridge:**
  - `management/commands/run_kafka_bridge.py`: Kafka 토픽(`alert`, `stock-ticks`)을 구독하고 웹소켓 그룹으로 브로드캐스팅하는 백그라운드 워커 구현
  - **데이터 정합성 확보:** Producer의 필드명(`stock_code`, `current_price`)과 Frontend 요구 규격(`code`, `price`) 간의 매핑 로직 적용

## 🔍 관련 이슈
- [I-43](https://github.com/gAemI-AI/gAemI-AI/issues/43)

## 🙏🏻 To Reviewers 
- 프론트엔드 연동 작업을 위한 [WebSocket API 명세서](https://www.notion.so/WebSocket-API-Final-2cf0c3d3c9ea80019b96ec13235b6ef0?source=copy_link)를 작성했습니다. swagger 상으로 확인이 불가하여 노션으로 별개 문서를 작성했습니다. 

## 📅 테스트 방법 (How to Test)
실제 장 운영 시간이 아니거나 Producer가 꺼져 있을 경우를 대비하여, **가짜 데이터 주입(Mocking)** 을 통한 테스트 절차를 안내합니다.

### 1. 컨테이너 실행
```bash
# Backend, Worker, Redis, Kafka 관련 컨테이너 실행
docker-compose up -d --build backend backend-worker redis kafka zookeeper

```

### 2. WebSocket 연결 (Client)

* **도구:** Postman (WebSocket Request) 


<img width="380" height="254" alt="image" src="https://github.com/user-attachments/assets/439e0113-eab9-4d36-b955-c782cb8ec813" />

<img width="602" height="445" alt="image" src="https://github.com/user-attachments/assets/d74604cf-0b34-4ccb-ab26-df788163bc03" />

<img width="857" height="658" alt="image" src="https://github.com/user-attachments/assets/6477b1f4-2fb2-4452-89ac-0ff4cb5609ef" />

* **알림 테스트 URL:** `ws://localhost:8000/ws/notifications/1/`
* **차트 테스트 URL:** `ws://localhost:8000/ws/stocks/005930/`
* 👉 위 주소로 **[Connect]** 버튼을 눌러 연결 상태(`Connected`)를 만듭니다.

### 3. gaemi_backend_worker 컨테이너 로그 확인 창 (WebSocket 클라이언트)
```bash
docker logs -f gaemi_backend_worker
````

### 4. Mock Data 주입 (3과 별도의 Terminal에서 실행)

새 터미널을 열고 Kafka 컨테이너 내부에서 직접 메시지를 쏴봅니다.

**A. 실시간 알림 테스트**

```bash
docker exec -it gaemi_kafka kafka-console-producer --bootstrap-server localhost:9092 --topic alert

```

(입력창 나오면 아래 JSON 붙여넣고 엔터)

```json
{"user_id": "1", "message": "테스트 알림입니다! 🚀"}

```

> **확인:** WebSocket 클라이언트에 `{"type": "alert", "data": "테스트 알림입니다! 🚀"}` 수신 확인

**B. 실시간 주식 차트 테스트**

```bash
docker exec -it gaemi_kafka kafka-console-producer --bootstrap-server localhost:9092 --topic stock-ticks

```

(입력창 나오면 아래 JSON 붙여넣고 엔터 - Producer 포맷 준수)

```json
{"stock_code": "005930", "current_price": 81000, "rate": 1.5, "timestamp": 1709123456789}

```

> **확인:** WebSocket 클라이언트에 `{"type": "chart_update", "data": {"code": "005930", "price": 81000, ...}}` 수신 확인

성공 화면
<img width="538" height="87" alt="image" src="https://github.com/user-attachments/assets/26328513-0dac-4d4d-bfde-dfbbbc4bece8" />
- 결과(메시지)는 다를 수 있습니다.

## ✅ 체크리스트

* [x] Redis 컨테이너가 Healthy 상태인가?
* [x] `backend-worker` 로그에 에러 없이 Listening 중인가?
* [x] WebSocket 연결 시 403 에러가 발생하지 않는가?
