### PR TITLE
[I-56] Elasticsearch 기반 종목 검색 엔진 도입(초성/오타 검색 지원)

### DIFF
--- a/gaemi-project/backend-pjt/requirements.txt
+++ b/gaemi-project/backend-pjt/requirements.txt
@@ -12,12 +12,12 @@ djangorestframework
 elasticsearch-dsl    # ES 통신용 (공식 라이브러리)
 openai               # GPT 호출용
 elasticsearch
-# elasticsearch>=8.0.0
 
 drf-yasg
+jamo==0.4.1
 
 # WebSocket & Redis 관련
 daphne>=4.0.0          # ASGI 서버
 channels>=4.0.0        # Django Channels
 channels-redis>=4.0.0  # Redis Channel Layer
-kafka-python>=2.0.2    # Kafka 연동
+kafka-python>=2.0.2    # Kafka 연동, 

--- a/gaemi-project/backend-pjt/stocks/management/commands/reindex_stocks.py
+++ b/gaemi-project/backend-pjt/stocks/management/commands/reindex_stocks.py
@@ -1,0 +1,100 @@
+# backend-pjt/stocks/management/commands/reindex_stocks.py
+
+from django.core.management.base import BaseCommand
+from elasticsearch import Elasticsearch, helpers
+from django.conf import settings
+from stocks.models import StockMaster
+from stocks.utils import get_chosung
+
+# 동의어 사전 (하드코딩으로 관리 - 필요 시 DB화 가능)
+SYNONYM_MAP = {
+    "NAVER": "네이버",
+    "POSCO홀딩스": "포스코",
+    "LG에너지솔루션": "엘지엔솔",
+    "SK하이닉스": "하이닉스", # '하이닉스'라고만 쳐도 SK하이닉스가 1순위로 뜨게 보조
+}
+
+class Command(BaseCommand):
+    help = 'StockMaster 데이터를 강력한 검색 기능을 위해 Elasticsearch로 인덱싱합니다.'
+
+    def handle(self, *args, **options):
+        es = Elasticsearch(["http://elasticsearch:9200"])
+        index_name = "stock-search"
+
+        # 1. 인덱스 설정 (Lowercase 필터 추가!)
+        if es.indices.exists(index=index_name):
+            es.indices.delete(index=index_name)
+            self.stdout.write(self.style.WARNING(f"기존 인덱스 '{index_name}' 삭제됨."))
+
+        settings_body = {
+            "settings": {
+                "analysis": {
+                    "tokenizer": {
+                        "ngram_tokenizer": {
+                            "type": "edge_ngram",
+                            "min_gram": 1,
+                            "max_gram": 20,
+                            "token_chars": ["letter", "digit", "punctuation", "symbol"] 
+                            # punctuation 추가: T.Rowe Price 같은 종목 대비
+                        }
+                    },
+                    "analyzer": {
+                        "ngram_analyzer": {
+                            "type": "custom",
+                            "tokenizer": "ngram_tokenizer",
+                            "filter": ["lowercase"] # 👈 핵심: 대소문자 무시 (SAMSUNG == samsung)
+                        }
+                    }
+                }
+            },
+            "mappings": {
+                "properties": {
+                    "stock_id": { "type": "keyword" },
+                    "stock_name": { 
+                        "type": "text", 
+                        "analyzer": "ngram_analyzer", 
+                        "search_analyzer": "standard" 
+                    },
+                    # 동의어도 검색되게 별도 필드 생성
+                    "stock_synonyms": {
+                         "type": "text",
+                         "analyzer": "ngram_analyzer",
+                         "search_analyzer": "standard"
+                    },
+                    "stock_name_chosung": { "type": "keyword" }, 
+                    "market_type": { "type": "keyword" }
+                }
+            }
+        }
+        
+        es.indices.create(index=index_name, body=settings_body)
+        self.stdout.write(self.style.SUCCESS(f"인덱스 '{index_name}' 생성 완료."))
+
+        # 2. 데이터 가공 및 동의어 주입
+        stocks = StockMaster.objects.all()
+        actions = []
+        
+        for stock in stocks:
+            # 동의어 찾기
+            synonym = SYNONYM_MAP.get(stock.stock_name, "")
+            
+            # 초성 변환 (SK하이닉스 -> skㅎㅇㄴㅅ)
+            chosung = get_chosung(stock.stock_name)
+            
+            doc = {
+                "_index": index_name,
+                "_id": stock.stock_id,
+                "_source": {
+                    "stock_id": stock.stock_id,
+                    "stock_name": stock.stock_name,
+                    "stock_synonyms": synonym, # "네이버" 등이 들어감
+                    "stock_name_chosung": chosung,
+                    "market_type": stock.market_type
+                }
+            }
+            actions.append(doc)
+
+        # 3. Bulk Insert
+        if actions:
+            helpers.bulk(es, actions)
+            self.stdout.write(self.style.SUCCESS(f"총 {len(actions)}건 인덱싱 완료!"))

--- a/gaemi-project/backend-pjt/stocks/services.py
+++ b/gaemi-project/backend-pjt/stocks/services.py
@@ -1,0 +1,64 @@
+# backend-pjt/stocks/services.py
+from elasticsearch import Elasticsearch
+from .utils import get_chosung
+
+class StockSearchService:
+    def __init__(self):
+        self.es = Elasticsearch(["http://elasticsearch:9200"])
+        self.index_name = "stock-search"
+
+    def search(self, keyword):
+        if not keyword:
+            return []
+
+        # 사용자 입력을 소문자로 변환 (검색 정확도 향상)
+        keyword_lower = keyword.lower()
+        
+        # 사용자 입력의 초성 변환 (ㅎㅇㄴㅅ 검색 지원용)
+        keyword_chosung = get_chosung(keyword)
+
+        query = {
+            "size": 50,
+            "query": {
+                "bool": {
+                    "should": [
+                        # 1. 종목코드 정확 일치 (가장 강력)
+                        { "term": { "stock_id": { "value": keyword, "boost": 100 } } },
+                        
+                        # 2. 종목명 정확/부분 일치 (대소문자 무시됨)
+                        { "match_phrase": { "stock_name": { "query": keyword, "boost": 50 } } },
+                        { "match": { "stock_name": { "query": keyword, "boost": 10 } } },
+                        
+                        # 3. [NEW] 동의어 검색 (네이버 -> NAVER 찾기)
+                        { "match": { "stock_synonyms": { "query": keyword, "boost": 40 } } },
+
+                        # 4. [NEW] 초성 검색 (skㅎㅇㄴㅅ)
+                        # 입력값이 "ㅎㅇㄴㅅ"이면 -> "*ㅎㅇㄴㅅ*" 패턴으로 skㅎㅇㄴㅅ를 찾음
+                        { "wildcard": { "stock_name_chosung": { "value": f"*{keyword_chosung}*", "boost": 5 } } },
+                        
+                        # 5. 오타 보정
+                        { "match": { "stock_name": { "query": keyword, "fuzziness": "AUTO", "boost": 1 } } }
+                    ],
+                    "minimum_should_match": 1
+                }
+            }
+        }
+
+        try:
+            response = self.es.search(index=self.index_name, body=query)
+            hits = response['hits']['hits']
+            
+            # Serializer와 유사한 형태로 데이터 반환
+            results = []
+            for hit in hits:
+                source = hit['_source']
+                results.append({
+                    "stock_id": source.get('stock_id'),
+                    "stock_name": source.get('stock_name'),
+                    "market_type": source.get('market_type')
+                })
+            return results
+        
+        except Exception as e:
+            print(f"ES Search Error: {e}")
+            return []

--- a/gaemi-project/backend-pjt/stocks/utils.py
+++ b/gaemi-project/backend-pjt/stocks/utils.py
@@ -1,0 +1,35 @@
+# backend-pjt/stocks/utils.py
+from jamo import h2j, j2hcj
+
+# 초성 리스트
+CHOSUNG_LIST = [
+    'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 
+    'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+]
+
+def get_chosung(text):
+    """
+    한글 문자열 -> 초성 추출
+    영어 문자열 -> 소문자 변환
+    예: "SK하이닉스" -> "skㅎㅇㄴㅅ"
+    """
+    if not text:
+        return ""
+    
+    # 1. 소문자 변환 (대소문자 무시를 위해)
+    text = text.lower()
+    
+    result = ""
+    for char in text:
+        # 한글인 경우 초성 추출
+        if '가' <= char <= '힣':
+            chosung_index = (ord(char) - 0xAC00) // 588
+            result += CHOSUNG_LIST[chosung_index]
+        # 한글 자음만 있는 경우 (ㄱ, ㄴ..)
+        elif 'ㄱ' <= char <= 'ㅎ':
+            result += char
+        # 영어/숫자/특수문자는 그대로 (소문자 상태)
+        else:
+            result += char
+            
+    return result

--- a/gaemi-project/backend-pjt/stocks/views.py
+++ b/gaemi-project/backend-pjt/stocks/views.py
@@ -13,6 +13,7 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from elasticsearch import Elasticsearch
+from .services import StockSearchService  
 
 # 주식 목록 조회 전용 뷰 (GET)
 class StockListView(generics.ListAPIView):
@@ -25,10 +26,22 @@ class StockListView(generics.ListAPIView):
     # 3. 누구에게 보여줄건지 -> 로그인한 사람에게만
     permission_classes = [AllowAny] # 모두에게 보여주려면 AllowAny으로 바꾸면 됨!
 
-    # 4. 검색 기능 활성화
-    filter_backends = [filters.SearchFilter]
-    search_fields = ['stock_name', 'stock_id', 'market_type']
+    def list(self, request, *args, **kwargs):
+        # 검색어 파라미터 가져오기 (?search=삼성)
+        keyword = request.query_params.get('search', '').strip()
 
+        # A. 검색어가 있다면 -> Elasticsearch 사용
+        if keyword:
+            service = StockSearchService()
+            es_results = service.search(keyword)
+            
+            # ES 결과를 그대로 반환 (Serializer를 거치지 않고 직접 리스트 반환)
+            # RDB 조회 비용 절약 + ES의 빠른 속도 활용
+            return Response(es_results, status=status.HTTP_200_OK)
+
+        # B. 검색어가 없다면 -> 기존 RDB Pagination 로직 사용
+        return super().list(request, *args, **kwargs)
+    
 # 주식 차트 데이터 조회 API (OHLC Aggregation)
 #   - ES의 주식 틱 데이터를 조회하여 지정된 시간 간격으로 집계한 캔들 데이터를 반환
 #   - URL: GET /api/v1/stocks/{stock_code}/chart/?range=1d&interval=1m


### PR DESCRIPTION
## 📌 개요
사용자 검색 경험(UX)을 대폭 개선하기 위해 Elasticsearch 기반의 종목 검색 엔진을 고도화했습니다. 단순 키워드 매칭을 넘어 초성 검색(예: ㅎㅇㄴㅅ), 동의어 검색(예: 네이버), 대소문자 무시 기능을 추가하고, 검색 결과가 없을 때 전체 목록이 노출되던 UX 문제를 해결했습니다.

## ✨ 주요 변경 사항
- [x] [Search] 검색 로직 고도화 (stocks/services.py)
- Multi-match Query 도입: 정확도 순으로 가중치(Boost) 부여 (종목코드 > 종목명 > 동의어 > 초성).
- get_chosung 유틸리티 적용: 한영 혼용 종목(SK하이닉스 → skㅎㅇㄴㅅ)에 대한 초성 검색 지원.

- [x] [Data] 인덱싱 스크립트 개선 (management/commands/reindex_stocks.py)
- Synonym Map 추가: NAVER 검색 시 네이버로도 찾을 수 있도록 동의어 필드 주입.
- Analyzer 설정: lowercase 필터를 적용하여 대소문자 구분 없이 검색 가능하도록 변경.

- [x] [Fix] 검색 UX 수정 (stocks/views.py)
- 기존: 검색 결과가 0건일 경우 전체 목록(super().list())을 반환하는 문제 수정.
- 변경: 검색어가 존재하면 결과가 없더라도 빈 배열([])을 반환하여 "검색 결과 없음"을 명확히 전달.

- [x] [BugFix] 모듈 import 누락 수정
- services.py에서 get_chosung 함수 import 누락으로 인한 NameError 해결.

## 🔍 관련 이슈
[I-56](https://github.com/gAemI-AI/gAemI-AI/issues/56)

## 🙏 To Reviewers
- 필수 실행: 인덱스 매핑(Mapping)과 데이터 구조가 변경되었으므로, 배포 후 반드시 재인덱싱(Re-indexing) 커맨드를 실행해야 정상 동작합니다. (테스트 방법 참고)
- 동의어 추가: 현재 NAVER, POSCO홀딩스 등 주요 종목에 대한 동의어가 하드코딩되어 있습니다. 추후 DB 관리 방식으로 고도화할 수 있습니다.


## 🧪 테스트 방법
1. 환경 재빌드 및 데이터 동기화 (필수)
매핑 설정 변경 및 라이브러리(jamo) 추가로 인해 빌드와 재적재가 필요합니다.
```Bash
2. 백엔드 재빌드
docker-compose up -d --build backend
```

3. 데이터 재적재 (Re-indexing)
```bash
docker exec -it gaemi_backend python manage.py reindex_stocks
```

<img width="789" height="58" alt="image" src="https://github.com/user-attachments/assets/ed816015-de9a-4066-b4b8-76198c061771" />


2. 검색 케이스 테스트 (Postman)
GET http://localhost:8000/api/v1/stocks/?search={키워드}
- 네이버 or naver 검색시 NAVER 반환
- sk하이닉스 or ㅎㅇㄴㅅ 검색시 SK하이닉스 반환
- 아무 문자나 검색했을 시 -> 빈 배열 ([])
<img width="853" height="616" alt="image" src="https://github.com/user-attachments/assets/9f64bcbf-64b2-48c3-85b3-745ee0468659" />

- 간혹 '네이버'와 같은 검색어를 넣었는데 전체 db 내용이 보이는 경우가 있습니다. 이 경우 다시 한번 send를 클릭하면 원하는 결과만 나옵니다! postman이 빈 배열이라고 인식해서 그런 경우라 다시 send하시면 키워드를 인식합니다