### PR TITLE
[I-55] (MVP) Stocks 조회 API(GET) 3종 프론트엔드 연동

### DIFF
--- a/gaemi-project/frontend-pjt/package-lock.json
+++ b/gaemi-project/frontend-pjt/package-lock.json
@@ -53,7 +53,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1637,7 +1636,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2650,7 +2648,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2869,7 +2866,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.24.tgz",
       "integrity": "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.24",
         "@vue/compiler-sfc": "3.5.24",

--- a/gaemi-project/frontend-pjt/src/api/stocks.js
+++ b/gaemi-project/frontend-pjt/src/api/stocks.js
@@ -1,0 +1,5 @@
+import axios from "@/api/axios"; // 이미 쓰고 있는 axios 인스턴스
+
+export const getStockChart = (stockCode) => {
+  return axios.get(`/api/v1/stocks/${stockCode}/chart/`);
+};

--- a/gaemi-project/frontend-pjt/src/components/dashboard/MarketSummaryPanel.vue
+++ b/gaemi-project/frontend-pjt/src/components/dashboard/MarketSummaryPanel.vue
@@ -2,11 +2,23 @@
   <div class="market-panel">
     <h3 class="panel-title">시장 지수</h3>
 
-    <div class="market-cards">
+    <!-- 로딩 -->
+    <div v-if="market.isLoading" class="empty">
+      시장 지수 불러오는 중...
+    </div>
+
+    <!-- 데이터 없음 -->
+    <div v-else-if="!market.kospi && !market.kosdaq" class="empty">
+      시장 지수 데이터가 없습니다.
+    </div>
+
+    <div v-else class="market-cards">
       <!-- 코스피 -->
-      <div class="market-card">
+      <div class="market-card" v-if="market.kospi">
         <div class="label">코스피</div>
-        <div class="price">{{ market.kospi.price.toLocaleString() }}</div>
+        <div class="price">
+          {{ market.kospi?.price.toLocaleString() }}
+        </div>
         <div
           class="diff"
           :class="{ up: market.kospi.diff >= 0, down: market.kospi.diff < 0 }"
@@ -19,10 +31,13 @@
         </div>
       </div>
 
+
       <!-- 코스닥 -->
-      <div class="market-card">
+      <div class="market-card" v-if="market.kosdaq">
         <div class="label">코스닥</div>
-        <div class="price">{{ market.kosdaq.price.toLocaleString() }}</div>
+        <div class="price">
+          {{ market.kosdaq?.price.toLocaleString() }}
+        </div>
         <div
           class="diff"
           :class="{ up: market.kosdaq.diff >= 0, down: market.kosdaq.diff < 0 }"
@@ -42,10 +57,13 @@
 import { onMounted } from "vue";
 import { useMarketStore } from "@/stores/marketStore";
 
+console.log("🔥 MarketSummaryPanel script loaded");
+
 const market = useMarketStore();
 
 onMounted(() => {
-  market.loadMock(); // 🔹 지금은 더미
+  console.log("🔥 MarketSummaryPanel mounted");
+  market.fetchMarketIndex(); // 🔹 지금은 더미
 });
 </script>
 

--- a/gaemi-project/frontend-pjt/src/components/dashboard/StockDetailCard.vue
+++ b/gaemi-project/frontend-pjt/src/components/dashboard/StockDetailCard.vue
@@ -95,7 +95,7 @@ const fetchChartData = async () => {
 
   try {
     const res = await api.get(
-      `/stocks/${props.stock.code}/chart/`,
+      `stocks/${props.stock.code}/chart/`,
       {
         params: {
           range: selectedRange.value.toLowerCase(), // 1d, 1w, 1m
@@ -116,6 +116,13 @@ const fetchChartData = async () => {
   } catch (e) {
     console.error('📉 chart fetch error', e);
   }
+
+  console.log({
+    prices: prices.value,
+    volumes: volumes.value,
+    xLabels: xLabels.value,
+  });
+
 };
 onMounted(fetchChartData);
 

--- a/gaemi-project/frontend-pjt/src/components/dashboard/StockDetailCard.vue
+++ b/gaemi-project/frontend-pjt/src/components/dashboard/StockDetailCard.vue
@@ -67,7 +67,8 @@
 </template>
 
 <script setup>
-import { computed, ref } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
+import api from '@/api/axios';
 
 const props = defineProps({
   stock: { type: Object, required: true },
@@ -81,23 +82,56 @@ const ranges = [
 ];
 
 const selectedRange = ref('1W');
+const xLabels = ref([]);
+const prices = ref([]);
+const volumes = ref([]);
 
-// 더미 데이터 (나중에 API 응답으로 교체)
-const xLabels = ['11월 14일', '11월 15일', '11월 16일', '11월 17일', '11월 18일', '11월 19일'];
-const prices = [72000, 71500, 70500, 69800, 71000, 70680];
-const volumes = [900000, 1200000, 800000, 1000000, 1100000, 950000];
+const maxPrice = computed(() => Math.max(...prices.value));
+const minPrice = computed(() => Math.min(...prices.value));
+const maxVolume = computed(() => Math.max(...volumes.value));
 
-const maxPrice = Math.max(...prices);
-const minPrice = Math.min(...prices);
-const maxVolume = Math.max(...volumes);
+const fetchChartData = async () => {
+  if (!props.stock?.code) return;
+
+  try {
+    const res = await api.get(
+      `/stocks/${props.stock.code}/chart/`,
+      {
+        params: {
+          range: selectedRange.value.toLowerCase(), // 1d, 1w, 1m
+          interval: '1d', // 지금은 고정 (나중에 수정해도 됨)
+        },
+      }
+    );
+
+    const data = res.data;
+
+    prices.value = data.map(d => d.y[3]);
+    volumes.value = data.map(d => d.v);
+
+    xLabels.value = data.map(d => {
+      const date = new Date(d.x);
+      return `${date.getMonth() + 1}/${date.getDate()}`;
+    });
+  } catch (e) {
+    console.error('📉 chart fetch error', e);
+  }
+};
+onMounted(fetchChartData);
+
+watch(selectedRange, () => {
+  fetchChartData();
+});
 
 const linePoints = computed(() => {
+  if (!prices.value.length) return '';
+
   const width = 100;
   const height = 40;
   const stepX = width / (prices.length - 1);
   const range = maxPrice - minPrice || 1;
 
-  return prices
+  return prices.value
     .map((p, i) => {
       const x = i * stepX;
       const y = height - ((p - minPrice) / range) * (height - 4) - 2;
@@ -105,6 +139,8 @@ const linePoints = computed(() => {
     })
     .join(' ');
 });
+
+
 </script>
 
 <style scoped>

--- a/gaemi-project/frontend-pjt/src/pages/DashboardPage.vue
+++ b/gaemi-project/frontend-pjt/src/pages/DashboardPage.vue
@@ -66,7 +66,7 @@
 import { ref, computed, onMounted } from "vue";
 import { useFavoritesStore } from "@/stores/favoritesStore.js";
 import { useAlertsStore } from "@/stores/alertsStore";
-
+import api from "@/api/axios";
 import StockSearchBar from "@/components/dashboard/StockSearchBar.vue";
 import StockTickerRow from "@/components/dashboard/StockTickerRow.vue";
 import StockDetailCard from "@/components/dashboard/StockDetailCard.vue";
@@ -99,10 +99,26 @@ const alertsStore = useAlertsStore();
 /* ------------------------------- */
 /* 로그인 유저 관심종목 불러오기   */
 /* ------------------------------- */
-onMounted(() => {
+onMounted(async () => {
   const user = JSON.parse(localStorage.getItem("user"));
   if (user?.favorites) {
     store.loadFavorites(user.favorites); // ⭐ Pinia에 로드
+  }
+
+  try {
+    const res = await api.get("/stocks/");
+    stocks.value = res.data.map((s) => ({
+      code: s.stock_id,
+      name: s.stock_name,
+      marketType: s.market_type,
+
+      price: 0,
+      change: 0,
+      changeRate: 0,
+    }));
+    console.log("[stocks]", res.data);
+  } catch (err) {
+    console.error('stocks 조회 실패', err);
   }
 });
 
@@ -118,24 +134,13 @@ const searchChartOpen = ref(false);
 /* -------------------------------------- */
 const favoriteSelectedStock = ref(null);
 const favoriteChartOpen = ref(false);
-
-/* -------------------------------------- */
-/* 더미 종목 데이터 */
-/* -------------------------------------- */
-const stocks = [
-  { code: '005930', name: '삼성전자', price: 70680, change: -1320, changeRate: -1.83 },
-  { code: '000660', name: 'SK하이닉스', price: 139421, change: 579, changeRate: 0.41 },
-  { code: '035420', name: 'NAVER', price: 215222, change: 3722, changeRate: 1.76 },
-  { code: '006400', name: '삼성SDI', price: 386519, change: -6481, changeRate: -1.65 },
-  { code: '005380', name: '현대차', price: 195740, change: 3240, changeRate: 1.68 }
-];
-
+const stocks = ref([]);
 /* -------------------------------------- */
 /* 검색 결과 필터링 */
 /* -------------------------------------- */
 const filteredStocks = computed(() => {
-  if (!searchKeyword.value) return stocks;
-  return stocks.filter(
+  if (!searchKeyword.value) return stocks.value;
+  return stocks.value.filter(
     (s) =>
       s.name.includes(searchKeyword.value) ||
       s.code.includes(searchKeyword.value)
@@ -146,7 +151,7 @@ const filteredStocks = computed(() => {
 // const favoriteStocks = computed(() => store.favorites);
 const favoriteStocks = computed(() =>
   store.favorites
-    .map(code => stocks.find(s => s.code === code))
+    .map(code => stocks.value.find(s => s.code === code))
     .filter(Boolean)
 );
 

--- a/gaemi-project/frontend-pjt/src/stores/marketStore.js
+++ b/gaemi-project/frontend-pjt/src/stores/marketStore.js
@@ -1,52 +1,50 @@
 // src/stores/marketStore.js
 import { defineStore } from "pinia";
+import api from "@/api/axios";
 
 export const useMarketStore = defineStore("market", {
   state: () => ({
-    // 시장 지수 요약
-    kospi: {
-      price: 2645.85,
-      diff: 15.32,
-      rate: 0.58,
-    },
-    kosdaq: {
-      price: 745.12,
-      diff: -3.45,
-      rate: -0.46,
-    },
+    kospi: null,
+    kosdaq: null,
 
     isLoading: false,
     lastUpdatedAt: null,
   }),
 
   getters: {
-    isKospiUp: (state) => state.kospi.diff >= 0,
-    isKosdaqUp: (state) => state.kosdaq.diff >= 0,
+    isKospiUp: (state) => state.kospi && state.kospi.diff >= 0,
+    isKosdaqUp: (state) => state.kosdaq && state.kosdaq.diff >= 0,
   },
 
   actions: {
-    /* ---------------------------------
-       🔹 더미 로딩 (현재 사용)
-    --------------------------------- */
-    loadMock() {
-      this.lastUpdatedAt = new Date().toISOString();
-    },
-
-    /* ---------------------------------
-       🔹 나중에 API 붙일 자리
-       예: GET /api/market/summary
-    --------------------------------- */
-    async fetchMarketSummary() {
+    async fetchMarketIndex() {
       this.isLoading = true;
 
       try {
-        // TODO: 실제 API 연결
-        // const res = await api.get("/market/summary");
-        // this.kospi = res.data.kospi;
-        // this.kosdaq = res.data.kosdaq;
+        const res = await api.get("/stocks/market-index/");
+        
+        const data = res.data;
+        if (!Array.isArray(data) || data.length === 0) {
+          this.kospi = null;
+          this.kosdaq = null;
+          this.lastUpdatedAt = new Date().toISOString();
+          return;
+        }
+        const kospi = data.find((m) => m.name === "KOSPI");
+        const kosdaq = data.find((m) => m.name === "KOSDAQ");
 
-        // 임시 mock (지금은 안 씀)
-        await new Promise((r) => setTimeout(r, 300));
+        this.kospi = kospi ? {
+          price: kospi.price,
+          diff: kospi.diff,
+          rate: kospi.rate,
+        } : null;
+
+        this.kosdaq = kosdaq ? {
+          price: kosdaq.price,
+          diff: kosdaq.diff,
+          rate: kosdaq.rate,
+        } : null;
+
         this.lastUpdatedAt = new Date().toISOString();
       } catch (e) {
         console.error("시장 지수 조회 실패", e);


### PR DESCRIPTION
## 📌 개요
인증(users) API 연동 이후, 대시보드 및 종목 상세 화면에서 사용하는 **주식 조회 관련 GET API 3종**을 프론트엔드에 연동했습니다.
본 PR은 **읽기 전영(GET) API 연동을 통해 Kafka → Flink → Elasticsearch로 이어지는 데이터 파이프라인이 프론트엔드 화면까지 정상적으로 전달되는지 검증**하는 것을 목표로 합니다.
UI 완성보다는 **API 호출 성공 여부와 실제 데이터 수신 확인**에 초점을 맞춰 작업했습니다.

## ✨ 주요 변경 사항
- [x] `GET /api/v1/stocks/` 프론트엔드 연동
   - 대시보드 진입 시 전체 종목 목록 조회 및 응답 데이터 매핑
- [x] `GET /api/v1/stocks/market-index/` 프론트엔드 연동
   - KOSPI / KOSDAQ 시장 지수 조회 및 대시보드 요약 패널 표시
- [x] `GET /api/v1/stocks/{stock_code}/chart/` 프론트엔드 연동
   - 종목 선택 시 차트 조회 API 호출 및 데이터 수신 확인
- [x] 인증 토큰 포함 요청 시 200 응답 확인

## 🔍 관련 이슈
- [I-55](https://github.com/gAemI-AI/gAemI-AI/issues/55)

## 🙏 To Reviewers
- 본 PR은 **UI 완성도보다는 API 연동 및 데이터 파이프라인 검증**을 목적으로 합니다.
- 시장 지수(`market-index`) 및 차트(`chart`) API의 경우 **Elasticsearch 인덱스 존재 여부 및 데이터 적재 상태에 따라 빈 배열이 반환될 수 있습니다.**

```
<!-- 추가적으로 필요한 경우 작성해주세요. -->
## 🧪 테스트 방법
1. `npm install` 실행
2. `npm run dev` 실행
3. 로그인 후 대시보드 진입
4. 네트워크 탭 또는 콘솔에서 아래 API 호출 및 응답 확인
  - `GET /api/v1/stocks/`
  - `GET /api/v1/stocks/market-index/`
  - `GET /api/v1/stocks/{stock_code}/chart/`